### PR TITLE
[205377] Contacts for academy

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.FiatDb/Repositories/FiatDataSourceRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.FiatDb/Repositories/FiatDataSourceRepository.cs
@@ -8,6 +8,7 @@ namespace DfE.FindInformationAcademiesTrusts.Data.FiatDb.Repositories;
 public interface IFiatDataSourceRepository
 {
     Task<DataSource> GetSchoolContactDataSourceAsync(int urn, SchoolContactRole role);
+    Task<DataSource> GetTrustContactDataSourceAsync(int uid, TrustContactRole role);
 }
 
 public class FiatDataSourceRepository(FiatDbContext dbContext) : IFiatDataSourceRepository
@@ -17,6 +18,15 @@ public class FiatDataSourceRepository(FiatDbContext dbContext) : IFiatDataSource
         return await dbContext
             .SchoolContacts
             .Where(contact => contact.Urn == urn && contact.Role == role)
+            .Select(t => new DataSource(Source.FiatDb, t.LastModifiedAtTime, null, t.LastModifiedByEmail))
+            .SingleOrDefaultAsync() ?? new DataSource(Source.FiatDb, null, null);
+    }
+
+    public async Task<DataSource> GetTrustContactDataSourceAsync(int uid, TrustContactRole role)
+    {
+        return await dbContext
+            .TrustContacts
+            .Where(contact => contact.Uid == uid && contact.Role == role)
             .Select(t => new DataSource(Source.FiatDb, t.LastModifiedAtTime, null, t.LastModifiedByEmail))
             .SingleOrDefaultAsync() ?? new DataSource(Source.FiatDb, null, null);
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/ContactsAreaModel.cs
@@ -1,10 +1,13 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.School;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 
@@ -12,9 +15,12 @@ public class ContactsAreaModel(
     ISchoolService schoolService,
     ITrustService trustService,
     IDataSourceService dataSourceService,
-    ISchoolNavMenu schoolNavMenu)
+    ISchoolNavMenu schoolNavMenu,
+    IVariantFeatureManager featureManager)
     : SchoolAreaModel(schoolService, trustService, schoolNavMenu)
 {
+    private readonly ITrustService _trustService = trustService;
+
     public const string PageName = "Contacts";
 
     public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
@@ -26,16 +32,62 @@ public class ContactsAreaModel(
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
         var giasDataSource = await dataSourceService.GetAsync(Source.Gias);
-        var fiatDataSource = await dataSourceService.GetSchoolContactDataSourceAsync(Urn, SchoolContactRole.RegionsGroupLocalAuthorityLead);
 
         DataSourcesPerPage =
         [
-            new DataSourcePageListEntry(InDfeModel.SubPageName,
-                [new DataSourceListEntry(fiatDataSource, "Regions group LA lead")]),
+            ..await GetInDfeDataSources(),
             new DataSourcePageListEntry(InSchoolModel.SubPageName(SchoolCategory),
                 [new DataSourceListEntry(giasDataSource, "Head teacher name")])
         ];
 
         return Page();
+    }
+
+    private async Task<DataSourcePageListEntry[]> GetInDfeDataSources()
+    {
+        if (!await ContactsInDfeForSchoolsEnabled()) return [];
+
+        return SchoolSummary.Category switch
+        {
+            SchoolCategory.LaMaintainedSchool => await GetInDfeDataSourcesForLocalAuthorityMaintainedSchool(),
+            SchoolCategory.Academy => await GetInDfeDataSourcesForAcademy(),
+            _ => throw new InvalidOperationException($"School category {SchoolSummary.Category} is not supported.")
+        };
+    }
+
+    private async Task<DataSourcePageListEntry[]> GetInDfeDataSourcesForLocalAuthorityMaintainedSchool()
+    {
+        var dataSource = await dataSourceService.GetSchoolContactDataSourceAsync(Urn, SchoolContactRole.RegionsGroupLocalAuthorityLead);
+        return
+        [
+            new DataSourcePageListEntry(InDfeModel.SubPageName,
+                [new DataSourceListEntry(dataSource, "Regions group LA lead")])
+        ];
+    }
+
+    private async Task<DataSourcePageListEntry[]> GetInDfeDataSourcesForAcademy()
+    {
+        var uid = (await _trustService.GetTrustSummaryAsync(Urn))?.Uid;
+
+        if (uid is null || !int.TryParse(uid, out var uidAsInt)) return [];
+
+        var trustRelationshipManagerDataSource =
+            await dataSourceService.GetTrustContactDataSourceAsync(uidAsInt, TrustContactRole.TrustRelationshipManager);
+        var sfsoLeadDataSource = await dataSourceService.GetTrustContactDataSourceAsync(uidAsInt, TrustContactRole.SfsoLead);
+
+        return
+        [
+            new DataSourcePageListEntry(InDfeModel.SubPageName,
+            [
+                new DataSourceListEntry(trustRelationshipManagerDataSource,
+                    TrustContactRole.TrustRelationshipManager.MapRoleToViewString()),
+                new DataSourceListEntry(sfsoLeadDataSource, TrustContactRole.SfsoLead.MapRoleToViewString())
+            ])
+        ];
+    }
+
+    private async Task<bool> ContactsInDfeForSchoolsEnabled()
+    {
+        return await featureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml
@@ -1,4 +1,5 @@
 @page "/schools/contacts/in-dfe"
+@using DfE.FindInformationAcademiesTrusts.Data.Enums
 @model InDfeModel
 
 @{
@@ -11,15 +12,41 @@
             @Model.PageMetadata.SubPageName
         </h2>
 
-        <div class="govuk-summary-card" data-testid="contact-card-regions-group-la-lead">
-            <div class="govuk-summary-card__title-wrapper">
-                <h3 class="govuk-summary-card__title" data-testid="contact-card-title-regions-group-la-lead">
-                    Regions group local authority lead
-                </h3>
+        @if (Model.SchoolCategory == SchoolCategory.LaMaintainedSchool)
+        {
+            <div class="govuk-summary-card" data-testid="contact-card-regions-group-la-lead">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h3 class="govuk-summary-card__title" data-testid="contact-card-title-regions-group-la-lead">
+                        Regions group local authority lead
+                    </h3>
+                </div>
+                <partial name="Contact/_DisplayContact" model="Model.RegionsGroupLocalAuthorityLead"
+                         view-data='new ViewDataDictionary(ViewData) { { "contactType", "regions-group-local-authority-lead" } }'/>
             </div>
-            <partial name="Contact/_DisplayContact" model="Model.RegionsGroupLocalAuthorityLead"
-                view-data='new ViewDataDictionary(ViewData) { { "contactType", "regions-group-local-authority-lead" } }' />
-        </div>
+        }
+
+        @if (Model.SchoolCategory == SchoolCategory.Academy)
+        {
+            <div class="govuk-summary-card" data-testid="contact-card-trust-relationship-manager">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h3 class="govuk-summary-card__title" data-testid="contact-card-title-trust-relationship-manager">
+                        Trust relationship manager
+                    </h3>
+                </div>
+                <partial name="Contact/_DisplayContact" model="Model.TrustRelationshipManager"
+                         view-data='new ViewDataDictionary(ViewData) { { "contactType", "trust-relationship-manager" } }'/>
+            </div>
+
+            <div class="govuk-summary-card" data-testid="contact-card-sfso-lead">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h3 class="govuk-summary-card__title" data-testid="contact-card-title-sfso-lead">
+                        SFSO (Schools Financial Support and Oversight) lead
+                    </h3>
+                </div>
+                <partial name="Contact/_DisplayContact" model="Model.SfsoLead"
+                         view-data='new ViewDataDictionary(ViewData) { { "contactType", "sfso-lead" } }'/>
+            </div>
+        }
         <hr class="govuk-section-break govuk-section-break--m" data-testid="contacts-section-divider">
     </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
@@ -25,7 +25,7 @@ public class InDfeModel(
 
     public static string SubPageName => "In DfE";
 
-    public Person RegionsGroupLocalAuthorityLead { get; private set; } = null!;
+    public Person? RegionsGroupLocalAuthorityLead { get; private set; }
 
     public override async Task<IActionResult> OnGetAsync()
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
@@ -26,6 +26,8 @@ public class InDfeModel(
     public static string SubPageName => "In DfE";
 
     public Person? RegionsGroupLocalAuthorityLead { get; private set; }
+    public Person? TrustRelationshipManager { get; private set; }
+    public Person? SfsoLead { get; private set; }
 
     public override async Task<IActionResult> OnGetAsync()
     {
@@ -35,6 +37,8 @@ public class InDfeModel(
         var contacts = await schoolContactsService.GetInternalContactsAsync(Urn);
 
         RegionsGroupLocalAuthorityLead = contacts.RegionsGroupLocalAuthorityLead;
+        TrustRelationshipManager = contacts.TrustRelationshipManager;
+        SfsoLead = contacts.SfsoLead;
 
         return pageResult;
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
@@ -5,6 +5,7 @@ using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.School;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement;
 using Microsoft.FeatureManagement.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
@@ -15,8 +16,9 @@ public class InDfeModel(
     ITrustService trustService,
     ISchoolContactsService schoolContactsService,
     IDataSourceService dataSourceService,
-    ISchoolNavMenu schoolNavMenu)
-    : ContactsAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu)
+    ISchoolNavMenu schoolNavMenu,
+    IVariantFeatureManager featureManager)
+    : ContactsAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu, featureManager)
 {
     public override PageMetadata PageMetadata => base.PageMetadata with
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InSchool.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InSchool.cshtml.cs
@@ -5,6 +5,7 @@ using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.School;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 
@@ -13,8 +14,9 @@ public class InSchoolModel(
     ITrustService trustService,
     ISchoolContactsService schoolContactsService,
     IDataSourceService dataSourceService,
-    ISchoolNavMenu schoolNavMenu)
-    : ContactsAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu)
+    ISchoolNavMenu schoolNavMenu,
+    IVariantFeatureManager featureManager)
+    : ContactsAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu, featureManager)
 {
     public override PageMetadata PageMetadata => base.PageMetadata with
     {

--- a/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceService.cs
@@ -11,6 +11,7 @@ public interface IDataSourceService
 {
     Task<DataSourceServiceModel> GetAsync(Source source);
     Task<DataSourceServiceModel> GetSchoolContactDataSourceAsync(int urn, SchoolContactRole role);
+    Task<DataSourceServiceModel> GetTrustContactDataSourceAsync(int uid, TrustContactRole role);
 }
 
 public class DataSourceService(
@@ -31,7 +32,7 @@ public class DataSourceService(
             Source.Gias or Source.Mstr or Source.Cdm or Source.Mis => await dataSourceRepository.GetAsync(source),
             Source.ExploreEducationStatistics => freeSchoolMealsAverageProvider.GetFreeSchoolMealsUpdated(),
             Source.Prepare or Source.Complete or Source.ManageFreeSchoolProjects =>
-               await dataSourceRepository.GetAsync(source),
+                await dataSourceRepository.GetAsync(source),
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
         };
 
@@ -57,6 +58,15 @@ public class DataSourceService(
     public async Task<DataSourceServiceModel> GetSchoolContactDataSourceAsync(int urn, SchoolContactRole role)
     {
         var dataSource = await fiatDataSourceRepository.GetSchoolContactDataSourceAsync(urn, role);
+        var dataSourceServiceModel = new DataSourceServiceModel(dataSource.Source, dataSource.LastUpdated,
+            dataSource.NextUpdated, dataSource.UpdatedBy);
+
+        return dataSourceServiceModel;
+    }
+
+    public async Task<DataSourceServiceModel> GetTrustContactDataSourceAsync(int uid, TrustContactRole role)
+    {
+        var dataSource = await fiatDataSourceRepository.GetTrustContactDataSourceAsync(uid, role);
         var dataSourceServiceModel = new DataSourceServiceModel(dataSource.Source, dataSource.LastUpdated,
             dataSource.NextUpdated, dataSource.UpdatedBy);
 

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolInternalContactsServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolInternalContactsServiceModel.cs
@@ -2,4 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Data;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.School;
 
-public record SchoolInternalContactsServiceModel(Person RegionsGroupLocalAuthorityLead);
+public record SchoolInternalContactsServiceModel(
+    Person? RegionsGroupLocalAuthorityLead = null,
+    Person? TrustRelationshipManager = null,
+    Person? SfsoLead = null);

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/schools/schoolContactPages/school-contact-pages.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/schools/schoolContactPages/school-contact-pages.cy.ts
@@ -83,7 +83,7 @@ describe('Testing the components of the School "in DfE" contacts page', () => {
     });
 });
 
-describe('Testing the components of the Academy "in DfE" contacts page (placeholder until in dfe academies are implemented)', () => {
+describe('Testing the components of the Academy "in DfE" contacts page', () => {
     beforeEach(() => {
         cy.visit(getInDfeContactsUrl(TEST_ACADEMY_URN));
     });
@@ -93,9 +93,44 @@ describe('Testing the components of the Academy "in DfE" contacts page (placehol
             .checkInDfeContactsSubpageHeaderIsCorrect();
     });
 
-    it('Checks the regions group LA lead contact card is present (placeholder behavior)', () => {
+    it('Checks the trust relationship manager contact card is present', () => {
         schoolsPage
-            .checkRegionsGroupLaLeadContactCardPresent();
+            .checkTrustRelationshipManagerContactCardPresent();
+    });
+
+    it('Checks the trust relationship manager contact title is displayed', () => {
+        schoolsPage
+            .checkTrustRelationshipManagerContactTitlePresent();
+    });
+
+    it('Checks the trust relationship manager contact name is displayed', () => {
+        schoolsPage
+            .checkTrustRelationshipManagerContactNamePresent();
+    });
+
+    it('Checks the trust relationship manager contact email is displayed', () => {
+        schoolsPage
+            .checkTrustRelationshipManagerContactEmailPresent();
+    });
+
+    it('Checks the SFSO lead contact card is present', () => {
+        schoolsPage
+            .checkSfsoLeadContactCardPresent();
+    });
+
+    it('Checks the SFSO lead contact title is displayed', () => {
+        schoolsPage
+            .checkSfsoLeadContactTitlePresent();
+    });
+
+    it('Checks the SFSO lead contact name is displayed', () => {
+        schoolsPage
+            .checkSfsoLeadContactNamePresent();
+    });
+
+    it('Checks the SFSO lead contact email is displayed', () => {
+        schoolsPage
+            .checkSfsoLeadContactEmailPresent();
     });
 
     it('Checks no internal use warning is present', () => {
@@ -103,9 +138,8 @@ describe('Testing the components of the Academy "in DfE" contacts page (placehol
             .checkNoInternalUseWarningPresent();
     });
 
-    // TODO: When academy implementation is complete in future feature, add tests for:
-    // - SFSO (Schools financial support and oversight) lead contact card
-    // - SFSO contact title, name, and email verification
-    // - Update to handle two contact cards instead of one
-    // - update  placeholder tests 
+    it('Checks no Change/Edit links are present for academy contacts (editing should be done at trust level only)', () => {
+        schoolsPage
+            .checkNoChangeLinksPresent();
+    });
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolsPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolsPage.ts
@@ -47,7 +47,10 @@ class SchoolsPage {
                 regionsGroupLaLeadTitle: () => cy.get('[data-testid="contact-card-title-regions-group-la-lead"]'),
                 regionsGroupLaLeadName: () => cy.get('[data-testid="contact-card-regions-group-la-lead"] [data-testid="contact-name"]'),
                 regionsGroupLaLeadEmail: () => cy.get('[data-testid="contact-card-regions-group-la-lead"] [data-testid="contact-email"]'),
-                // TODO: SFSO contact elements for future academy implementation
+                trustRelationshipManagerCard: () => cy.get('[data-testid="contact-card-trust-relationship-manager"]'),
+                trustRelationshipManagerTitle: () => cy.get('[data-testid="contact-card-title-trust-relationship-manager"]'),
+                trustRelationshipManagerName: () => cy.get('[data-testid="contact-card-trust-relationship-manager"] [data-testid="contact-name"]'),
+                trustRelationshipManagerEmail: () => cy.get('[data-testid="contact-card-trust-relationship-manager"] [data-testid="contact-email"]'),
                 sfsoLeadCard: () => cy.get('[data-testid="contact-card-sfso-lead"]'),
                 sfsoLeadTitle: () => cy.get('[data-testid="contact-card-title-sfso-lead"]'),
                 sfsoLeadName: () => cy.get('[data-testid="contact-card-sfso-lead"] [data-testid="contact-name"]'),
@@ -296,7 +299,6 @@ class SchoolsPage {
         return this;
     }
 
-    // TODO: SFSO contact methods for future academy implementation
     public checkSfsoLeadContactCardPresent(): this {
         this.elements.schoolContacts.inDfEContacts.sfsoLeadCard().should('be.visible');
         this.elements.schoolContacts.inDfEContacts.sfsoLeadName().should('be.visible');
@@ -305,7 +307,7 @@ class SchoolsPage {
     }
 
     public checkSfsoLeadContactTitlePresent(): this {
-        this.elements.schoolContacts.inDfEContacts.sfsoLeadTitle().should('be.visible').and('contain', 'SFSO (Schools financial support and oversight) lead');
+        this.elements.schoolContacts.inDfEContacts.sfsoLeadTitle().should('be.visible').and('contain', 'SFSO (Schools Financial Support and Oversight) lead');
         return this;
     }
 
@@ -319,6 +321,31 @@ class SchoolsPage {
         this.elements.schoolContacts.inDfEContacts.sfsoLeadEmail().should('not.contain.text', 'No contact email available');
         this.elements.schoolContacts.inDfEContacts.sfsoLeadEmail().should('not.be.empty');
         this.elements.schoolContacts.inDfEContacts.sfsoLeadEmail().should('have.attr', 'href').and('match', /^mailto:/);
+        return this;
+    }
+
+    public checkTrustRelationshipManagerContactCardPresent(): this {
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerCard().should('be.visible');
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerName().should('be.visible');
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerEmail().should('be.visible');
+        return this;
+    }
+
+    public checkTrustRelationshipManagerContactTitlePresent(): this {
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerTitle().should('be.visible').and('contain', 'Trust relationship manager');
+        return this;
+    }
+
+    public checkTrustRelationshipManagerContactNamePresent(): this {
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerName().should('not.contain.text', 'No contact name available');
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerName().should('not.be.empty');
+        return this;
+    }
+
+    public checkTrustRelationshipManagerContactEmailPresent(): this {
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerEmail().should('not.contain.text', 'No contact email available');
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerEmail().should('not.be.empty');
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerEmail().should('have.attr', 'href').and('match', /^mailto:/);
         return this;
     }
 
@@ -358,6 +385,15 @@ class SchoolsPage {
         return this;
     }
     // #endregion
+
+    public checkNoChangeLinksPresent(): this {
+        // Verify no "Change" or "Edit" links are present in the academy contacts section
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerCard().should('not.contain', 'Change');
+        this.elements.schoolContacts.inDfEContacts.trustRelationshipManagerCard().should('not.contain', 'Edit');
+        this.elements.schoolContacts.inDfEContacts.sfsoLeadCard().should('not.contain', 'Change');
+        this.elements.schoolContacts.inDfEContacts.sfsoLeadCard().should('not.contain', 'Edit');
+        return this;
+    }
 }
 
 const schoolsPage = new SchoolsPage();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Repositories/FiatDataSourceRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Repositories/FiatDataSourceRepositoryTests.cs
@@ -17,7 +17,8 @@ public class FiatDataSourceRepositoryTests : BaseFiatDbTest
     [Fact]
     public async Task GetSchoolContactDataSourceAsync_returns_empty_datasource_when_no_contact_exists_for_school()
     {
-        var result = await _sut.GetSchoolContactDataSourceAsync(123456, SchoolContactRole.RegionsGroupLocalAuthorityLead);
+        var result =
+            await _sut.GetSchoolContactDataSourceAsync(123456, SchoolContactRole.RegionsGroupLocalAuthorityLead);
 
         using (new AssertionScope())
         {
@@ -30,7 +31,9 @@ public class FiatDataSourceRepositoryTests : BaseFiatDbTest
 
     [Theory]
     [InlineData(SchoolContactRole.RegionsGroupLocalAuthorityLead)]
-    public async Task GetSchoolContactDataSourceAsync_returns_empty_datasource_when_no_contact_with_role_exists_for_school(SchoolContactRole role)
+    public async Task
+        GetSchoolContactDataSourceAsync_returns_empty_datasource_when_no_contact_with_role_exists_for_school(
+            SchoolContactRole role)
     {
         FiatDbContext.SchoolContacts.Add(new SchoolContact
         {
@@ -54,7 +57,9 @@ public class FiatDataSourceRepositoryTests : BaseFiatDbTest
 
     [Theory]
     [InlineData(SchoolContactRole.RegionsGroupLocalAuthorityLead)]
-    public async Task GetSchoolContactDataSourceAsync_returns_datasource_with_expected_data_when_contact_with_role_exists_for_school(SchoolContactRole role)
+    public async Task
+        GetSchoolContactDataSourceAsync_returns_datasource_with_expected_data_when_contact_with_role_exists_for_school(
+            SchoolContactRole role)
     {
         FiatDbContext.SchoolContacts.Add(new SchoolContact
         {
@@ -66,6 +71,77 @@ public class FiatDataSourceRepositoryTests : BaseFiatDbTest
         await FiatDbContext.SaveChangesAsync();
 
         var result = await _sut.GetSchoolContactDataSourceAsync(123456, role);
+
+        using (new AssertionScope())
+        {
+            result.Source.Should().Be(Source.FiatDb);
+            result.LastUpdated.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+            result.NextUpdated.Should().BeNull();
+            result.UpdatedBy.Should().Be("user@defaulttest");
+        }
+    }
+
+    [Theory]
+    [InlineData(TrustContactRole.TrustRelationshipManager)]
+    [InlineData(TrustContactRole.SfsoLead)]
+    public async Task GetTrustContactDataSourceAsync_returns_empty_datasource_when_no_contact_exists_for_trust(
+        TrustContactRole role)
+    {
+        var result = await _sut.GetTrustContactDataSourceAsync(4321, role);
+
+        using (new AssertionScope())
+        {
+            result.Source.Should().Be(Source.FiatDb);
+            result.LastUpdated.Should().BeNull();
+            result.NextUpdated.Should().BeNull();
+            result.UpdatedBy.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData(TrustContactRole.TrustRelationshipManager, "Trust Relationship Manager", "trm@education.gov.uk")]
+    [InlineData(TrustContactRole.SfsoLead, "SFSO Lead", "sfso@education.gov.uk")]
+    public async Task
+        GetTrustContactDataSourceAsync_returns_empty_datasource_when_no_contact_with_role_exists_for_trust(
+            TrustContactRole role, string name, string email)
+    {
+        FiatDbContext.TrustContacts.Add(new TrustContact
+        {
+            Uid = 4321,
+            Role = role,
+            Name = name,
+            Email = email
+        });
+        await FiatDbContext.SaveChangesAsync();
+
+        var result = await _sut.GetTrustContactDataSourceAsync(4321, (TrustContactRole)(-1));
+
+        using (new AssertionScope())
+        {
+            result.Source.Should().Be(Source.FiatDb);
+            result.LastUpdated.Should().BeNull();
+            result.NextUpdated.Should().BeNull();
+            result.UpdatedBy.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData(TrustContactRole.TrustRelationshipManager, "Trust Relationship Manager", "trm@education.gov.uk")]
+    [InlineData(TrustContactRole.SfsoLead, "SFSO Lead", "sfso@education.gov.uk")]
+    public async Task
+        GetTrustContactDataSourceAsync_returns_datasource_with_expected_data_when_contact_with_role_exists_for_trust(
+            TrustContactRole role, string name, string email)
+    {
+        FiatDbContext.TrustContacts.Add(new TrustContact
+        {
+            Uid = 4321,
+            Role = role,
+            Name = name,
+            Email = email
+        });
+        await FiatDbContext.SaveChangesAsync();
+
+        var result = await _sut.GetTrustContactDataSourceAsync(4321, role);
 
         using (new AssertionScope())
         {

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
@@ -24,6 +24,10 @@ public static class MockDataSourceService
             .GetSchoolContactDataSourceAsync(Arg.Any<int>(), Arg.Any<SchoolContactRole>())
             .Returns(Fiat);
 
+        mockDataSourceService
+            .GetTrustContactDataSourceAsync(Arg.Any<int>(), Arg.Any<TrustContactRole>())
+            .Returns(Fiat);
+
         return mockDataSourceService;
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/BaseContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/BaseContactsAreaModelTests.cs
@@ -1,12 +1,17 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
-using DocumentFormat.OpenXml.Office2010.Excel;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.FeatureManagement;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Contacts;
 
 public abstract class BaseContactsAreaModelTests<T> : BaseSchoolPageTests<T> where T : ContactsAreaModel
 {
+    protected readonly IVariantFeatureManager MockFeatureManager = Substitute.For<IVariantFeatureManager>();
+
     [Fact]
     public override async Task OnGetAsync_should_configure_PageMetadata_PageName()
     {
@@ -18,25 +23,41 @@ public abstract class BaseContactsAreaModelTests<T> : BaseSchoolPageTests<T> whe
     [Fact]
     public override async Task OnGetAsync_sets_correct_data_source_list()
     {
-        await OnGetAsync_sets_correct_data_source_list_for_academy();
+        await OnGetAsync_sets_correct_data_source_list_for_academy_when_ContactsInDfeForSchools_feature_flag_is_enabled();
+        MockDataSourceService.ClearReceivedCalls();
+        MockTrustService.ClearReceivedCalls();
 
+        await OnGetAsync_sets_correct_data_source_list_for_academy_when_ContactsInDfeForSchools_feature_flag_is_disabled();
+        MockDataSourceService.ClearReceivedCalls();
+        MockTrustService.ClearReceivedCalls();
+
+        await OnGetAsync_sets_correct_data_source_list_for_school_when_ContactsInDfeForSchools_feature_flag_is_enabled();
         MockDataSourceService.ClearReceivedCalls();
 
-        await OnGetAsync_sets_correct_data_source_list_for_school();
+        await OnGetAsync_sets_correct_data_source_list_for_school_when_ContactsInDfeForSchools_feature_flag_is_disabled();
+        MockDataSourceService.ClearReceivedCalls();
     }
 
-    private async Task OnGetAsync_sets_correct_data_source_list_for_academy()
+    private async Task OnGetAsync_sets_correct_data_source_list_for_academy_when_ContactsInDfeForSchools_feature_flag_is_enabled()
     {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(true);
+        MockTrustService.GetTrustSummaryAsync(AcademyUrn)
+            .Returns(new TrustSummaryServiceModel("4321", "Some Trust", "Some trust type", 1));
+
         Sut.Urn = AcademyUrn;
 
         _ = await Sut.OnGetAsync();
         await MockDataSourceService.Received(1).GetAsync(Source.Gias);
         await MockDataSourceService.Received(1)
-            .GetSchoolContactDataSourceAsync(AcademyUrn, SchoolContactRole.RegionsGroupLocalAuthorityLead);
+            .GetTrustContactDataSourceAsync(4321, TrustContactRole.TrustRelationshipManager);
+        await MockDataSourceService.Received(1)
+            .GetTrustContactDataSourceAsync(4321, TrustContactRole.SfsoLead);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry("In DfE", [
-                new DataSourceListEntry(Mocks.MockDataSourceService.Fiat, "Regions group LA lead")
+                new DataSourceListEntry(Mocks.MockDataSourceService.Fiat, "Trust relationship manager"),
+                new DataSourceListEntry(Mocks.MockDataSourceService.Fiat,
+                    "SFSO (Schools financial support and oversight) lead")
             ]),
             new DataSourcePageListEntry("In this academy", [
                 new DataSourceListEntry(Mocks.MockDataSourceService.Gias, "Head teacher name")
@@ -44,8 +65,32 @@ public abstract class BaseContactsAreaModelTests<T> : BaseSchoolPageTests<T> whe
         ]);
     }
 
-    private async Task OnGetAsync_sets_correct_data_source_list_for_school()
+    private async Task OnGetAsync_sets_correct_data_source_list_for_academy_when_ContactsInDfeForSchools_feature_flag_is_disabled()
     {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(false);
+        MockTrustService.GetTrustSummaryAsync(AcademyUrn)
+            .Returns(new TrustSummaryServiceModel("4321", "Some Trust", "Some trust type", 1));
+
+        Sut.Urn = AcademyUrn;
+
+        _ = await Sut.OnGetAsync();
+        await MockDataSourceService.Received(1).GetAsync(Source.Gias);
+        await MockDataSourceService.DidNotReceive()
+            .GetTrustContactDataSourceAsync(4321, TrustContactRole.TrustRelationshipManager);
+        await MockDataSourceService.DidNotReceive()
+            .GetTrustContactDataSourceAsync(4321, TrustContactRole.SfsoLead);
+
+        Sut.DataSourcesPerPage.Should().BeEquivalentTo([
+            new DataSourcePageListEntry("In this academy", [
+                new DataSourceListEntry(Mocks.MockDataSourceService.Gias, "Head teacher name")
+            ])
+        ]);
+    }
+
+    private async Task OnGetAsync_sets_correct_data_source_list_for_school_when_ContactsInDfeForSchools_feature_flag_is_enabled()
+    {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(true);
+
         Sut.Urn = SchoolUrn;
 
         _ = await Sut.OnGetAsync();
@@ -57,6 +102,24 @@ public abstract class BaseContactsAreaModelTests<T> : BaseSchoolPageTests<T> whe
             new DataSourcePageListEntry("In DfE", [
                 new DataSourceListEntry(Mocks.MockDataSourceService.Fiat, "Regions group LA lead")
             ]),
+            new DataSourcePageListEntry("In this school", [
+                new DataSourceListEntry(Mocks.MockDataSourceService.Gias, DataField: "Head teacher name")
+            ])
+        ]);
+    }
+
+    private async Task OnGetAsync_sets_correct_data_source_list_for_school_when_ContactsInDfeForSchools_feature_flag_is_disabled()
+    {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(false);
+
+        Sut.Urn = SchoolUrn;
+
+        _ = await Sut.OnGetAsync();
+        await MockDataSourceService.Received(1).GetAsync(Source.Gias);
+        await MockDataSourceService.DidNotReceive()
+            .GetSchoolContactDataSourceAsync(SchoolUrn, SchoolContactRole.RegionsGroupLocalAuthorityLead);
+
+        Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry("In this school", [
                 new DataSourceListEntry(Mocks.MockDataSourceService.Gias, DataField: "Head teacher name")
             ])

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InDfeModelTests.cs
@@ -9,7 +9,9 @@ public class InDfeModelTests : BaseContactsAreaModelTests<InDfeModel>
     private readonly ISchoolContactsService _mockSchoolContactsService = Substitute.For<ISchoolContactsService>();
 
     private readonly SchoolInternalContactsServiceModel _dummySchoolContactsServiceModel =
-        new(new Person("Aaron Aaronson", "aa@education.gov.uk"));
+        new(new Person("Aaron Aaronson", "aa@education.gov.uk"),
+            new Person("Bertha Billingsley", "bb@education.gov.uk"),
+            new Person("Carlton Coriander", "cc@education.gov.uk"));
 
     public InDfeModelTests()
     {
@@ -56,5 +58,21 @@ public class InDfeModelTests : BaseContactsAreaModelTests<InDfeModel>
         await Sut.OnGetAsync();
 
         Sut.RegionsGroupLocalAuthorityLead.Should().Be(_dummySchoolContactsServiceModel.RegionsGroupLocalAuthorityLead);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_TrustRelationshipManager_contact_details()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.TrustRelationshipManager.Should().Be(_dummySchoolContactsServiceModel.TrustRelationshipManager);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_SfsoLead_contact_details()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.SfsoLead.Should().Be(_dummySchoolContactsServiceModel.SfsoLead);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InDfeModelTests.cs
@@ -18,7 +18,7 @@ public class InDfeModelTests : BaseContactsAreaModelTests<InDfeModel>
         _mockSchoolContactsService.GetInternalContactsAsync(Arg.Any<int>()).Returns(_dummySchoolContactsServiceModel);
 
         Sut = new InDfeModel(MockSchoolService, MockTrustService, _mockSchoolContactsService, MockDataSourceService,
-                MockSchoolNavMenu)
+                MockSchoolNavMenu, MockFeatureManager)
         { Urn = SchoolUrn };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InSchoolModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InSchoolModelTests.cs
@@ -18,7 +18,7 @@ public class InSchoolModelTests : BaseContactsAreaModelTests<InSchoolModel>
         _mockSchoolContactsService.GetInSchoolContactsAsync(Arg.Any<int>()).Returns(_dummyInSchoolContacts);
 
         Sut = new InSchoolModel(MockSchoolService, MockTrustService, _mockSchoolContactsService, MockDataSourceService,
-                MockSchoolNavMenu)
+                MockSchoolNavMenu, MockFeatureManager)
         { Urn = SchoolUrn };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolContactsServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolContactsServiceTests.cs
@@ -3,14 +3,18 @@ using DfE.FindInformationAcademiesTrusts.Data.FiatDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Contacts;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
 using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using FluentAssertions.Execution;
 using NSubstitute.ReturnsExtensions;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
 
 public class SchoolContactsServiceTests
 {
-    private readonly int _urn = 123;
+    private readonly int _urn = 100123;
+    private readonly string _uid = "1234";
     private readonly SchoolContactsService _sut;
+    private readonly ITrustService _mockTrustService = Substitute.For<ITrustService>();
     private readonly ISchoolRepository _mockSchoolRepository = Substitute.For<ISchoolRepository>();
     private readonly IContactRepository _mockContactsRepository = Substitute.For<IContactRepository>();
 
@@ -22,7 +26,7 @@ public class SchoolContactsServiceTests
 
     public SchoolContactsServiceTests()
     {
-        _sut = new SchoolContactsService(_mockSchoolRepository, _mockContactsRepository);
+        _sut = new SchoolContactsService(_mockTrustService, _mockSchoolRepository, _mockContactsRepository);
     }
 
     [Fact]
@@ -62,25 +66,93 @@ public class SchoolContactsServiceTests
     [Fact]
     public async Task GetInternalContactsAsync_should_set_RegionsGroupLocalAuthorityLead_details_from_repository()
     {
-        var expectedResult = new SchoolInternalContactsServiceModel(new Person("Regions Group Local Authority Lead",
-            "regions.group.local.authority.lead@education.gov.uk"));
+        var regionsGroupLocalAuthorityLead = new Person("Regions Group Local Authority Lead",
+            "regions.group.local.authority.lead@education.gov.uk");
 
         _mockContactsRepository.GetSchoolInternalContactsAsync(_urn).Returns(_dummyInternalContacts);
 
         var result = await _sut.GetInternalContactsAsync(_urn);
 
-        result.Should().BeEquivalentTo(expectedResult);
+        result.RegionsGroupLocalAuthorityLead.Should().BeEquivalentTo(regionsGroupLocalAuthorityLead);
     }
 
     [Fact]
-    public async Task GetInternalContactsAsync_should_default_null_RegionsGroupLocalAuthorityLead_to_empty_string_name_and_null_email()
+    public async Task
+        GetInternalContactsAsync_should_set_RegionsGroupLocalAuthorityLead_to_null_when_repository_does_not_provide_one()
     {
-        var expectedResult = new SchoolInternalContactsServiceModel(new Person(string.Empty, null));
-
         _mockContactsRepository.GetSchoolInternalContactsAsync(_urn).Returns(new SchoolInternalContacts(null));
 
         var result = await _sut.GetInternalContactsAsync(_urn);
 
-        result.Should().BeEquivalentTo(expectedResult);
+        result.RegionsGroupLocalAuthorityLead.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task
+        GetInternalContactsAsync_should_set_TrustRelationshipManager_and_SfsoLead_details_from_TrustService()
+    {
+        var trmContact = new InternalContact("Trust Relationship Manager", "trm@education.gov.uk",
+            default, string.Empty);
+        var trmPerson = new Person("Trust Relationship Manager", "trm@education.gov.uk");
+        var sfsoLeadContact = new InternalContact("SFSO Lead", "sfso@education.gov.uk", default, string.Empty);
+        var sfsoLeadPerson = new Person("SFSO Lead", "sfso@education.gov.uk");
+
+        _mockContactsRepository.GetSchoolInternalContactsAsync(_urn).Returns(_dummyInternalContacts);
+        _mockTrustService.GetTrustSummaryAsync(_urn)
+            .Returns(new TrustSummaryServiceModel(_uid, "Some Trust", "Some Trust Type", 1));
+        _mockContactsRepository.GetTrustInternalContactsAsync(_uid)
+            .Returns(new TrustInternalContacts(trmContact, sfsoLeadContact));
+
+        var result = await _sut.GetInternalContactsAsync(_urn);
+
+        using (new AssertionScope())
+        {
+            result.TrustRelationshipManager.Should().BeEquivalentTo(trmPerson);
+            result.SfsoLead.Should().BeEquivalentTo(sfsoLeadPerson);
+        }
+    }
+
+    [Fact]
+    public async Task
+        GetInternalContactsAsync_should_set_null_TrustRelationshipManager_when_TrustService_does_not_provide_one()
+    {
+        var sfsoLeadContact = new InternalContact("SFSO Lead", "sfso@education.gov.uk", default, string.Empty);
+        var sfsoLeadPerson = new Person("SFSO Lead", "sfso@education.gov.uk");
+
+        _mockContactsRepository.GetSchoolInternalContactsAsync(_urn).Returns(_dummyInternalContacts);
+        _mockTrustService.GetTrustSummaryAsync(_urn)
+            .Returns(new TrustSummaryServiceModel(_uid, "Some Trust", "Some Trust Type", 1));
+        _mockContactsRepository.GetTrustInternalContactsAsync(_uid)
+            .Returns(new TrustInternalContacts(null, sfsoLeadContact));
+
+        var result = await _sut.GetInternalContactsAsync(_urn);
+
+        using (new AssertionScope())
+        {
+            result.TrustRelationshipManager.Should().BeNull();
+            result.SfsoLead.Should().BeEquivalentTo(sfsoLeadPerson);
+        }
+    }
+
+    [Fact]
+    public async Task GetInternalContactsAsync_should_set_null_SfsoLead_when_TrustService_does_not_provide_one()
+    {
+        var trmContact = new InternalContact("Trust Relationship Manager", "trm@education.gov.uk",
+            default, string.Empty);
+        var trmPerson = new Person("Trust Relationship Manager", "trm@education.gov.uk");
+
+        _mockContactsRepository.GetSchoolInternalContactsAsync(_urn).Returns(_dummyInternalContacts);
+        _mockTrustService.GetTrustSummaryAsync(_urn)
+            .Returns(new TrustSummaryServiceModel(_uid, "Some Trust", "Some Trust Type", 1));
+        _mockContactsRepository.GetTrustInternalContactsAsync(_uid)
+            .Returns(new TrustInternalContacts(trmContact, null));
+
+        var result = await _sut.GetInternalContactsAsync(_urn);
+
+        using (new AssertionScope())
+        {
+            result.TrustRelationshipManager.Should().BeEquivalentTo(trmPerson);
+            result.SfsoLead.Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 205377](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205377): Build: Contacts for academy. Other branches for this feature should be merged into this one.

This PR updates the 'In DfE' contacts page for academies to display the contact information for the managing trust, rather than the regions group local authority lead (which is not applicable to an academy as they are not accountable to the local authority).

## Changes
- The `SchoolContactsService.GetInternalContactsAsync` method will now fetch contact information from the managing trust, if the school is an academy
- The `SchoolInternalContactsServiceModel` now can optionally hold information about the trust relationship manager and the SFSO lead when the school is an academy
- The `SchoolContactsService.GetInternalContactsAsync` method now retrieves information from the managing trust if a school is an academy
- The `FiatDataSourceRepository.GetTrustContactDataSourceAsync` method has been added to retrieve the data source details from the database for a trust contact
- The `DataSourceService.GetTrustContactDataSourceAsync` method has been added to provide data source information about a trust contact
- The contacts shown on the 'Contacts in DfE' page when the school being viewed is an academy are now the **trust relationship manager** and the **SFSO (schools financial support and oversight) lead**
- The "Where this information came from" section now uses the `ContactsForDfeForSchools` feature flag to determine whether to provide information about the "in DfE" contacts

## Screenshots of UI changes

### Before

An academy showing the regions group local authority lead:
![](https://github.com/user-attachments/assets/4046e4c2-d63f-42d9-92c9-d6b2057c7823)

Incorrect behaviour  - displaying "In DfE" data in the "Where this information came from" section when the `ContactsForDfeForSchools` feature flag is disabled:
![](https://github.com/user-attachments/assets/d2db8a22-2546-41c9-835f-7b1666f69e94)

### After

An academy showing contact details for its managing trust:
![](https://github.com/user-attachments/assets/dbd2bac5-0c4c-4c83-8c33-401486081ecb)

A local authority maintained school, which is unaffected by these changes:
![](https://github.com/user-attachments/assets/303468a0-d190-4d9a-afd5-8bed49ce9748)

An academy showing only information about the head teacher name in the "Where this information came from" section when the `ContactsForDfeForSchools` feature flag is disabled:
![](https://github.com/user-attachments/assets/1acdbbe4-52b4-402f-9b73-bc2284fb93bd)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
