### PR TITLE
[202080] Add a 'reference numbers' page to the school overview area

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/SchoolRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/SchoolRepository.cs
@@ -140,4 +140,10 @@ public class SchoolRepository(
 
         return schoolFederationDetails;
     }
+
+    public async Task<SchoolReferenceNumbers?> GetReferenceNumbersAsync(int urn)
+    {
+        return await academiesDbContext.GiasEstablishments.Where(e => e.Urn == urn)
+            .Select(e => new SchoolReferenceNumbers(e.LaCode, e.EstablishmentNumber, e.Ukprn)).SingleOrDefaultAsync();
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/ISchoolRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/ISchoolRepository.cs
@@ -15,4 +15,6 @@ public interface ISchoolRepository
     Task<bool> IsPartOfFederationAsync(int urn);
 
     Task<FederationDetails> GetSchoolFederationDetailsAsync(int urn);
+
+    Task<SchoolReferenceNumbers?> GetReferenceNumbersAsync(int urn);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/SchoolReferenceNumbers.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/SchoolReferenceNumbers.cs
@@ -1,0 +1,3 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
+
+public record SchoolReferenceNumbers(string? LaCode, string? EstablishmentNumber, string? Ukprn);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
@@ -30,7 +30,9 @@ public abstract class OverviewAreaModel(
             new DataSourcePageListEntry(DetailsModel.SubPageName(SchoolCategory),
                 [new DataSourceListEntry(giasDataSource)]),
             new DataSourcePageListEntry(FederationModel.SubPageName,
-            [new DataSourceListEntry(giasDataSource)]),
+                [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(ReferenceNumbersModel.SubPageName,
+                [new DataSourceListEntry(giasDataSource)]),
             new DataSourcePageListEntry(SenModel.SubPageName,
                 [new DataSourceListEntry(giasDataSource)])
         ];

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/ReferenceNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/ReferenceNumbers.cshtml
@@ -1,0 +1,45 @@
+@page
+@model ReferenceNumbersModel
+
+@{
+  Layout = "_SchoolLayout";
+}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m" data-testid="subpage-header">
+      Reference numbers
+    </h2>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-width-two-thirds" data-testid="reference-numbers-urn-header">
+          URN (Unique Reference Number)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          @Model.Urn
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-width-two-thirds" data-testid="reference-numbers-laestab-header">
+          LAESTAB (local authority establishment number)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          @Model.Laestab
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-width-two-thirds" data-testid="reference-numbers-ukprn-header">
+          UKPRN (UK provider reference number)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          @Model.Ukprn
+        </dd>
+      </div>
+
+      <hr class="govuk-section-break govuk-section-break--m">
+    </dl>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/ReferenceNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/ReferenceNumbers.cshtml.cs
@@ -1,0 +1,38 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
+
+public class ReferenceNumbersModel(
+    ISchoolService schoolService,
+    ITrustService trustService,
+    IDataSourceService dataSourceService,
+    ISchoolNavMenu schoolNavMenu) : OverviewAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu)
+{
+    public const string SubPageName = "Reference numbers";
+
+    public override PageMetadata PageMetadata =>
+        base.PageMetadata with { SubPageName = SubPageName };
+
+    private readonly ISchoolService _schoolService = schoolService;
+
+    public string Laestab { get; set; } = null!;
+    public string Ukprn { get; set; } = null!;
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+
+        if (pageResult is NotFoundResult) return pageResult;
+
+        var referenceNumbers = await _schoolService.GetReferenceNumbersAsync(Urn);
+
+        Laestab = referenceNumbers.Laestab ?? "Not available";
+        Ukprn = referenceNumbers.Ukprn ?? "Not available";
+
+        return pageResult;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
@@ -75,6 +75,14 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
             ));
         }
 
+        links.Add(GetSubNavLinkTo<ReferenceNumbersModel>(
+            OverviewAreaModel.PageName,
+            ReferenceNumbersModel.SubPageName,
+            "/Schools/Overview/ReferenceNumbers",
+            activePage,
+            "overview-reference-numbers-subnav"
+        ));
+
         links.Add(GetSubNavLinkTo<SenModel>(
             OverviewAreaModel.PageName,
             SenModel.SubPageName,

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolReferenceNumbersServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolReferenceNumbersServiceModel.cs
@@ -1,0 +1,3 @@
+namespace DfE.FindInformationAcademiesTrusts.Services.School;
+
+public record SchoolReferenceNumbersServiceModel(int Urn, string? Laestab = null, string? Ukprn = null);

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
@@ -8,6 +8,8 @@ public interface ISchoolService
     Task<SchoolSummaryServiceModel?> GetSchoolSummaryAsync(int urn);
 
     Task<bool> IsPartOfFederationAsync(int urn);
+
+    Task<SchoolReferenceNumbersServiceModel> GetReferenceNumbersAsync(int urn);
 }
 
 public class SchoolService(IMemoryCache memoryCache, ISchoolRepository schoolRepository) : ISchoolService
@@ -40,5 +42,18 @@ public class SchoolService(IMemoryCache memoryCache, ISchoolRepository schoolRep
             new MemoryCacheEntryOptions { SlidingExpiration = TimeSpan.FromMinutes(10) });
 
         return schoolSummaryServiceModel;
+    }
+
+    public async Task<SchoolReferenceNumbersServiceModel> GetReferenceNumbersAsync(int urn)
+    {
+        var referenceNumbers = await schoolRepository.GetReferenceNumbersAsync(urn);
+
+        if (referenceNumbers is null) return new SchoolReferenceNumbersServiceModel(urn);
+
+        var laestab = referenceNumbers.LaCode is not null && referenceNumbers.EstablishmentNumber is not null
+            ? $"{referenceNumbers.LaCode}/{referenceNumbers.EstablishmentNumber}"
+            : null;
+
+        return new SchoolReferenceNumbersServiceModel(urn, laestab, referenceNumbers.Ukprn);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/BaseOverviewAreaModelTests.cs
@@ -37,6 +37,8 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseSchoolPageTests<T> whe
             ]),
             new DataSourcePageListEntry("Federation details",
                 [new DataSourceListEntry(Mocks.MockDataSourceService.Gias)]),
+            new DataSourcePageListEntry("Reference numbers",
+                [new DataSourceListEntry(Mocks.MockDataSourceService.Gias)]),
             new DataSourcePageListEntry("SEN (special educational needs)",
                 [new DataSourceListEntry(Mocks.MockDataSourceService.Gias)])
         ]);
@@ -54,6 +56,8 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseSchoolPageTests<T> whe
                 new DataSourceListEntry(Mocks.MockDataSourceService.Gias)
             ]),
             new DataSourcePageListEntry("Federation details",
+                [new DataSourceListEntry(Mocks.MockDataSourceService.Gias)]),
+            new DataSourcePageListEntry("Reference numbers",
                 [new DataSourceListEntry(Mocks.MockDataSourceService.Gias)]),
             new DataSourcePageListEntry("SEN (special educational needs)",
                 [new DataSourceListEntry(Mocks.MockDataSourceService.Gias)])

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/ReferenceNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/ReferenceNumbersModelTests.cs
@@ -1,0 +1,70 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Overview;
+
+public class ReferenceNumbersModelTests : BaseOverviewAreaModelTests<ReferenceNumbersModel>
+{
+    private const string Laestab = "123/4567";
+    private const string Ukprn = "12345678";
+
+    public ReferenceNumbersModelTests()
+    {
+        MockGetReferenceNumbersMethodToReturn(Laestab, Ukprn);
+
+        Sut = new ReferenceNumbersModel(MockSchoolService, MockTrustService, MockDataSourceService, MockSchoolNavMenu)
+        {
+            Urn = SchoolUrn
+        };
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_PageMetadata_SubPageName()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.SubPageName.Should().Be("Reference numbers");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_laestab_correctly()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.Laestab.Should().Be(Laestab);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_handle_null_laestab()
+    {
+        MockGetReferenceNumbersMethodToReturn(null, Ukprn);
+
+        await Sut.OnGetAsync();
+
+        Sut.Laestab.Should().Be("Not available");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_ukprn()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.Ukprn.Should().Be(Ukprn);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_handle_null_ukprn()
+    {
+        MockGetReferenceNumbersMethodToReturn(Laestab, null);
+
+        await Sut.OnGetAsync();
+
+        Sut.Ukprn.Should().Be("Not available");
+    }
+
+    private void MockGetReferenceNumbersMethodToReturn(string? laestab, string? ukprn)
+    {
+        MockSchoolService.GetReferenceNumbersAsync(Arg.Any<int>())
+            .Returns(a => new SchoolReferenceNumbersServiceModel(a.Arg<int>(), laestab, ukprn));
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
@@ -145,6 +145,7 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
             nameof(InSchoolModel) => contactLink,
             nameof(SenModel) => "/Schools/Overview/Details",
             nameof(FederationModel) => "/Schools/Overview/Details",
+            nameof(ReferenceNumbersModel) => "/Schools/Overview/Details",
             _ => throw new ArgumentException("Couldn't get expected service nav asp link for given page type",
                 nameof(pageType))
         };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
@@ -46,6 +46,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
             nameof(InSchoolModel) => "Contacts",
             nameof(SenModel) => "Overview",
             nameof(FederationModel) => "Overview",
+            nameof(ReferenceNumbersModel) => "Overview",
             _ => throw new ArgumentException("Couldn't get expected name for given page type", nameof(pageType))
         };
     }
@@ -89,6 +90,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
             nameof(InSchoolModel) => "/Schools/Contacts/InSchool",
             nameof(SenModel) => "/Schools/Overview/Sen",
             nameof(FederationModel) => "/Schools/Overview/Federation",
+            nameof(ReferenceNumbersModel) => "/Schools/Overview/ReferenceNumbers",
             _ => throw new ArgumentException("Couldn't get expected sub page nav asp link for given page type",
                 nameof(pageType))
         };
@@ -97,7 +99,8 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
     [Theory]
     [InlineData(SchoolCategory.LaMaintainedSchool, "School details")]
     [InlineData(SchoolCategory.Academy, "Academy details")]
-    public async Task GetSubNavLinksAsync_should_return_expected_links_for_overview_when_federation(SchoolCategory schoolCategory,
+    public async Task GetSubNavLinksAsync_should_return_expected_links_for_overview_when_federation(
+        SchoolCategory schoolCategory,
         string expectedText)
     {
         var activePage = GetMockSchoolPage(typeof(DetailsModel), schoolCategory: schoolCategory);
@@ -116,6 +119,12 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
                 l.LinkDisplayText.Should().Be("Federation details");
                 l.AspPage.Should().Be("/Schools/Overview/Federation");
                 l.TestId.Should().Be("overview-federation-subnav");
+            },
+            l =>
+            {
+                l.LinkDisplayText.Should().Be("Reference numbers");
+                l.AspPage.Should().Be("/Schools/Overview/ReferenceNumbers");
+                l.TestId.Should().Be("overview-reference-numbers-subnav");
             },
             l =>
             {
@@ -143,6 +152,12 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
                 l.LinkDisplayText.Should().Be(expectedText);
                 l.AspPage.Should().Be("/Schools/Overview/Details");
                 l.TestId.Should().Be("overview-details-subnav");
+            },
+            l =>
+            {
+                l.LinkDisplayText.Should().Be("Reference numbers");
+                l.AspPage.Should().Be("/Schools/Overview/ReferenceNumbers");
+                l.TestId.Should().Be("overview-reference-numbers-subnav");
             },
             l =>
             {

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
@@ -24,6 +24,7 @@ public abstract class SchoolNavMenuTestsBase
         typeof(DetailsModel),
         typeof(SenModel),
         typeof(FederationModel),
+        typeof(ReferenceNumbersModel),
         //Contacts
         typeof(InSchoolModel)
     ];
@@ -33,6 +34,7 @@ public abstract class SchoolNavMenuTestsBase
         //Overview
         typeof(DetailsModel),
         typeof(SenModel),
+        typeof(ReferenceNumbersModel),
         //Contacts
         typeof(InDfeModel),
         typeof(InSchoolModel)


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 202080](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/202080): Build: School/academy reference numbers. Other branches for this feature should be merged into this one.

This PR introduces a page to view the reference numbers for a school or academy.

## Changes

- The `SchoolRepository` class now has a `GetReferenceNumbersAsync` method that returns a `SchoolReferenceNumbers` record containing the LA code, establishment number, and UKPRN for the school with the given URN
- The `SchoolService` class now also has a `GetReferenceNumbersAsync` method that returns a `SchoolReferenceNumbersServiceModel`, which contains the URN, the LAESTAB (a combined reference containing the LA code and the establishment number), and UKPRN
- Added the `ReferenceNumbers.cshtml` page and `ReferenceNumbersModel` page model to present the reference numbers page to the user
- Updated the school subnav menu for the 'Overview' section to link to the 'Reference numbers' page
- Added an item to the 'Where this information came from' section of the overview page to indicate to users where the reference numbers were sourced

## Screenshots of UI changes

### Before

No page is available to view the reference numbers, no subnav menu entry exists, and no mention in the 'Where this information came from' section:
![](https://github.com/user-attachments/assets/dfdda0b9-b01a-4fc2-bca6-e6352fbf6a30)

### After

Displaying the reference numbers on a dedicated page, with its own subnav menu entry and an updated 'Where this information came from' section:
![](https://github.com/user-attachments/assets/fc2f2cd4-beb8-4b18-af83-d581be368236)

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
