### PR TITLE
[205477] Add support for multiple data sources for a single piece of information

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/DataSourceRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/DataSourceRepository.cs
@@ -18,7 +18,7 @@ public class DataSourceRepository(
             Source.Gias => await GetDataSourceFromApplicationEvents("GIAS_Daily", Source.Gias, UpdateFrequency.Daily),
             Source.Mstr => await GetDataSourceFromApplicationEvents("MSTR_Daily", Source.Mstr, UpdateFrequency.Daily),
             Source.Cdm => await GetDataSourceFromApplicationEvents("CDM_Daily", Source.Cdm, UpdateFrequency.Daily),
-            Source.Mis => await GetMisEstablishmentsUpdatedAsync(),
+            Source.Mis or Source.MisFurtherEducation => await GetMisEstablishmentsUpdatedAsync(source),
             Source.Prepare
             or Source.Complete
             or Source.ManageFreeSchoolProjects => await GetDataSourceFromMstr(source),
@@ -26,17 +26,17 @@ public class DataSourceRepository(
         };
     }
 
-    public async Task<DataSource> GetMisEstablishmentsUpdatedAsync()
+    private async Task<DataSource> GetMisEstablishmentsUpdatedAsync(Source source)
     {
         var lastEntry = await academiesDbContext.ApplicationSettings
             .FirstOrDefaultAsync(e => e.Key == "ManagementInformationSchoolTableData CSV Filename");
         if (lastEntry?.Modified is null)
         {
             logger.LogError("Unable to find when ManagementInformationSchoolTableData was last modified");
-            return new DataSource(Source.Mis, null, UpdateFrequency.Monthly);
+            return new DataSource(source, null, UpdateFrequency.Monthly);
         }
 
-        return new DataSource(Source.Mis, lastEntry.Modified.Value, UpdateFrequency.Monthly);
+        return new DataSource(source, lastEntry.Modified.Value, UpdateFrequency.Monthly);
     }
 
     /// <summary>

--- a/DfE.FindInformationAcademiesTrusts.Data/Enums/Source.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Enums/Source.cs
@@ -6,6 +6,7 @@ public enum Source
     Mstr,
     Cdm,
     Mis,
+    MisFurtherEducation,
     ExploreEducationStatistics,
     FiatDb,
     Prepare,

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/DataSourceListEntry.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/DataSourceListEntry.cs
@@ -20,6 +20,7 @@ public record DataSourceListEntry(DataSourceServiceModel DataSource, string Data
         Source.Mstr => "Get information about schools (internal use only, do not share outside of DfE)",
         Source.Cdm => "RSD (Regional Services Division) service support team",
         Source.Mis => "State-funded school inspections and outcomes: management information",
+        Source.MisFurtherEducation => "Further education and skills inspections and outcomes: management information",
         Source.ExploreEducationStatistics => "Explore education statistics",
         Source.FiatDb => "Find information about schools and trusts",
         Source.Prepare => "Prepare",

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/DataSourceListEntry.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/DataSourceListEntry.cs
@@ -4,30 +4,78 @@ using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 
-public record DataSourceListEntry(DataSourceServiceModel DataSource, string DataField = "All information was")
+public record DataSourceListEntry(List<DataSourceServiceModel> DataSources, string DataField = "All information was")
 {
-    public string LastUpdatedText => DataSource.LastUpdated is null
-        ? "Unknown"
-        : DataSource.LastUpdated.Value.ToString(StringFormatConstants.DisplayDateFormat);
-
-    public string? UpdatedByText => DataSource.UpdatedBy == "TRAMs Migration"
-        ? "TRAMS Migration"
-        : DataSource.UpdatedBy;
-
-    public string Name => DataSource.Source switch
+    public DataSourceListEntry(DataSourceServiceModel dataSource, string DataField = "All information was") : this(
+        [dataSource], DataField)
     {
-        Source.Gias => "Get information about schools",
-        Source.Mstr => "Get information about schools (internal use only, do not share outside of DfE)",
-        Source.Cdm => "RSD (Regional Services Division) service support team",
-        Source.Mis => "State-funded school inspections and outcomes: management information",
-        Source.MisFurtherEducation => "Further education and skills inspections and outcomes: management information",
-        Source.ExploreEducationStatistics => "Explore education statistics",
-        Source.FiatDb => "Find information about schools and trusts",
-        Source.Prepare => "Prepare",
-        Source.Complete => "Complete",
-        Source.ManageFreeSchoolProjects => "Manage free school projects",
-        _ => "Unknown"
-    };
+    }
 
-    public string TestId => $"data-source-{DataSource.Source.ToString()}-{DataField}".Kebabify();
+    public static string GetLastUpdatedText(DataSourceServiceModel dataSource)
+    {
+        return dataSource.LastUpdated is null
+            ? "Unknown"
+            : dataSource.LastUpdated.Value.ToString(StringFormatConstants.DisplayDateFormat);
+    }
+
+    public static string? GetUpdatedByText(DataSourceServiceModel dataSource)
+    {
+        return dataSource.UpdatedBy == "TRAMs Migration"
+            ? "TRAMS Migration"
+            : dataSource.UpdatedBy;
+    }
+
+    public string TestId =>
+        $"data-source-{string.Join('-', DataSources.Select(ds => ds.Source))}-{DataField}".Kebabify();
+
+    public static string GetName(DataSourceServiceModel dataSource)
+    {
+        return dataSource.Source switch
+        {
+            Source.Gias => "Get information about schools",
+            Source.Mstr => "Get information about schools (internal use only, do not share outside of DfE)",
+            Source.Cdm => "RSD (Regional Services Division) service support team",
+            Source.Mis => "State-funded school inspections and outcomes: management information",
+            Source.MisFurtherEducation =>
+                "Further education and skills inspections and outcomes: management information",
+            Source.ExploreEducationStatistics => "Explore education statistics",
+            Source.FiatDb => "Find information about schools and trusts",
+            Source.Prepare => "Prepare",
+            Source.Complete => "Complete",
+            Source.ManageFreeSchoolProjects => "Manage free school projects",
+            _ => "Unknown"
+        };
+    }
+
+    public override string ToString()
+    {
+        if (DataSources.Count == 1)
+        {
+            var dataSource = DataSources[0];
+            return dataSource.UpdatedBy is null
+                ? $"{DataField} taken from {GetDataSourceText(dataSource)}"
+                : $"{DataField} updated by {GetDataSourceText(dataSource)}";
+        }
+
+        if (DataSources.Count == 2)
+        {
+            var firstDataSource = DataSources[0];
+            var secondDataSource = DataSources[1];
+            return
+                $"{DataField} taken from {GetDataSourceText(firstDataSource)} and {GetDataSourceText(secondDataSource)}";
+        }
+
+        var lastDataSource = DataSources[^1];
+        var rest = DataSources.Take(DataSources.Count - 1);
+
+        return
+            $"{DataField} taken from {string.Join(", ", rest.Select(GetDataSourceText))}, and {GetDataSourceText(lastDataSource)}";
+    }
+
+    private static string GetDataSourceText(DataSourceServiceModel dataSource)
+    {
+        return dataSource.UpdatedBy is null
+            ? $"{GetName(dataSource)} on {GetLastUpdatedText(dataSource)}"
+            : $"{GetUpdatedByText(dataSource)} on {GetLastUpdatedText(dataSource)}";
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/_SourceList.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/_SourceList.cshtml
@@ -19,14 +19,7 @@
           @foreach (var source in pageSource.DataSources)
           {
             <li data-testid="@source.TestId">
-              @if (source.DataSource.UpdatedBy is not null)
-              {
-                <span>@source.DataField was updated by @source.UpdatedByText on @source.LastUpdatedText</span>
-              }
-              else
-              {
-                <span>@source.DataField taken from @source.Name on @source.LastUpdatedText</span>
-              }
+              <span>@source.ToString()</span>
             </li>
           }
         </ul>

--- a/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceService.cs
@@ -29,7 +29,8 @@ public class DataSourceService(
 
         var dataSource = source switch
         {
-            Source.Gias or Source.Mstr or Source.Cdm or Source.Mis => await dataSourceRepository.GetAsync(source),
+            Source.Gias or Source.Mstr or Source.Cdm or Source.Mis or Source.MisFurtherEducation =>
+                await dataSourceRepository.GetAsync(source),
             Source.ExploreEducationStatistics => freeSchoolMealsAverageProvider.GetFreeSchoolMealsUpdated(),
             Source.Prepare or Source.Complete or Source.ManageFreeSchoolProjects =>
                 await dataSourceRepository.GetAsync(source),

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/DataSourceRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/DataSourceRepositoryTests.cs
@@ -32,6 +32,7 @@ public class DataSourceRepositoryTests
     [InlineData(Source.Cdm, UpdateFrequency.Daily)]
     [InlineData(Source.Gias, UpdateFrequency.Daily)]
     [InlineData(Source.Mis, UpdateFrequency.Monthly)]
+    [InlineData(Source.MisFurtherEducation, UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, UpdateFrequency.Daily)]
     [InlineData(Source.Prepare, UpdateFrequency.Daily)]
     [InlineData(Source.Complete, UpdateFrequency.Daily)]
@@ -58,6 +59,8 @@ public class DataSourceRepositoryTests
     [InlineData(Source.Cdm, "Unable to find when CDM_Daily was last run", UpdateFrequency.Daily)]
     [InlineData(Source.Gias, "Unable to find when GIAS_Daily was last run", UpdateFrequency.Daily)]
     [InlineData(Source.Mis, "Unable to find when ManagementInformationSchoolTableData was last modified",
+        UpdateFrequency.Monthly)]
+    [InlineData(Source.MisFurtherEducation, "Unable to find when ManagementInformationSchoolTableData was last modified",
         UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, "Unable to find when MSTR_Daily was last run", UpdateFrequency.Daily)]
     [InlineData(Source.Prepare, "Unable to find last data refresh for MSTR source 'Prepare'", UpdateFrequency.Daily)]
@@ -112,7 +115,7 @@ public class DataSourceRepositoryTests
         if (source is not Source.Gias) _mockAcademiesDbContext.AddApplicationEvent("GIAS_Daily", lastUpdateTime);
         if (source is not Source.Mstr) _mockAcademiesDbContext.AddApplicationEvent("MSTR_Daily", lastUpdateTime);
         if (source is not Source.Cdm) _mockAcademiesDbContext.AddApplicationEvent("CDM_Daily", lastUpdateTime);
-        if (source is not Source.Mis)
+        if (source is not Source.Mis && source is not Source.MisFurtherEducation)
             _mockAcademiesDbContext.AddApplicationSetting("ManagementInformationSchoolTableData CSV Filename",
                 lastUpdateTime);
         if (source is not Source.Prepare)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/DataSource/DataSourceListEntryTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/DataSource/DataSourceListEntryTest.cs
@@ -63,6 +63,7 @@ public class DataSourceListEntryTest
     [InlineData(Source.Mstr, "Get information about schools (internal use only, do not share outside of DfE)")]
     [InlineData(Source.Cdm, "RSD (Regional Services Division) service support team")]
     [InlineData(Source.Mis, "State-funded school inspections and outcomes: management information")]
+    [InlineData(Source.MisFurtherEducation, "Further education and skills inspections and outcomes: management information")]
     [InlineData(Source.ExploreEducationStatistics, "Explore education statistics")]
     [InlineData(Source.FiatDb, "Find information about schools and trusts")]
     public void Name_should_return_the_correct_string_for_each_source(Source source, string expected)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/DataSource/DataSourceListEntryTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/DataSource/DataSourceListEntryTest.cs
@@ -9,39 +9,38 @@ public class DataSourceListEntryTest
     private readonly DataSourceServiceModel _dataSourceServiceModel = new(Source.Cdm, null, null);
 
     [Fact]
-    public void LastUpdatedText_returns_unknown_when_LastUpdated_is_null()
+    public void GetLastUpdatedText_returns_unknown_when_LastUpdated_is_null()
     {
-        var sut = new DataSourceListEntry(_dataSourceServiceModel with { LastUpdated = null });
-        sut.LastUpdatedText.Should().Be("Unknown");
+        DataSourceListEntry.GetLastUpdatedText(_dataSourceServiceModel with { LastUpdated = null }).Should()
+            .Be("Unknown");
     }
 
     [Fact]
-    public void LastUpdatedText_returns_correctString_when_LastUpdated_is_set()
+    public void GetLastUpdatedText_returns_correctString_when_LastUpdated_is_set()
     {
         var date = DateTime.Today;
-        var sut = new DataSourceListEntry(_dataSourceServiceModel with { LastUpdated = date });
-        sut.LastUpdatedText.Should().Be(date.ToString("dd MMM yyyy"));
+        DataSourceListEntry.GetLastUpdatedText(_dataSourceServiceModel with { LastUpdated = date }).Should()
+            .Be(date.ToString("dd MMM yyyy"));
     }
 
     [Fact]
-    public void UpdatedByText_returns_null_when_UpdatedBy_is_null()
+    public void GetUpdatedByText_returns_null_when_UpdatedBy_is_null()
     {
-        var sut = new DataSourceListEntry(_dataSourceServiceModel with { UpdatedBy = null });
-        sut.UpdatedByText.Should().Be(null);
+        DataSourceListEntry.GetUpdatedByText(_dataSourceServiceModel with { UpdatedBy = null }).Should().Be(null);
     }
 
     [Fact]
-    public void UpdatedByText_returns_correctString_when_UpdatedBy_is_set()
+    public void GetUpdatedByText_returns_correctString_when_UpdatedBy_is_set()
     {
-        var sut = new DataSourceListEntry(_dataSourceServiceModel with { UpdatedBy = "Updated by" });
-        sut.UpdatedByText.Should().Be("Updated by");
+        DataSourceListEntry.GetUpdatedByText(_dataSourceServiceModel with { UpdatedBy = "Updated by" }).Should()
+            .Be("Updated by");
     }
 
     [Fact]
-    public void UpdatedByText_returns_correctString_when_UpdatedBy_is_set_to_TRAMs_Migration()
+    public void GetUpdatedByText_returns_correctString_when_UpdatedBy_is_set_to_TRAMs_Migration()
     {
-        var sut = new DataSourceListEntry(_dataSourceServiceModel with { UpdatedBy = "TRAMs Migration" });
-        sut.UpdatedByText.Should().Be("TRAMS Migration");
+        DataSourceListEntry.GetUpdatedByText(_dataSourceServiceModel with { UpdatedBy = "TRAMs Migration" }).Should()
+            .Be("TRAMS Migration");
     }
 
     [Fact]
@@ -63,20 +62,19 @@ public class DataSourceListEntryTest
     [InlineData(Source.Mstr, "Get information about schools (internal use only, do not share outside of DfE)")]
     [InlineData(Source.Cdm, "RSD (Regional Services Division) service support team")]
     [InlineData(Source.Mis, "State-funded school inspections and outcomes: management information")]
-    [InlineData(Source.MisFurtherEducation, "Further education and skills inspections and outcomes: management information")]
+    [InlineData(Source.MisFurtherEducation,
+        "Further education and skills inspections and outcomes: management information")]
     [InlineData(Source.ExploreEducationStatistics, "Explore education statistics")]
     [InlineData(Source.FiatDb, "Find information about schools and trusts")]
-    public void Name_should_return_the_correct_string_for_each_source(Source source, string expected)
+    public void GetName_should_return_the_correct_string_for_each_source(Source source, string expected)
     {
-        var sut = new DataSourceListEntry(_dataSourceServiceModel with { Source = source });
-        sut.Name.Should().Be(expected);
+        DataSourceListEntry.GetName(_dataSourceServiceModel with { Source = source }).Should().Be(expected);
     }
 
     [Fact]
-    public void Name_should_return_Unknown_when_source_is_not_recognised()
+    public void GetName_should_return_Unknown_when_source_is_not_recognised()
     {
-        var sut = new DataSourceListEntry(_dataSourceServiceModel with { Source = (Source)100 });
-        sut.Name.Should().Be("Unknown");
+        DataSourceListEntry.GetName(_dataSourceServiceModel with { Source = (Source)100 }).Should().Be("Unknown");
     }
 
     [Theory]
@@ -87,5 +85,87 @@ public class DataSourceListEntryTest
     {
         var sut = new DataSourceListEntry(_dataSourceServiceModel with { Source = source }, dataField);
         sut.TestId.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("data-source-gias-mstr-all-information-was", Source.Gias, Source.Mstr)]
+    [InlineData("data-source-mis-misfurthereducation-gias-all-information-was", Source.Mis, Source.MisFurtherEducation,
+        Source.Gias)]
+    public void TestId_should_combine_multiple_data_sources(string expected, params Source[] sources)
+    {
+        var sut = new DataSourceListEntry(sources.Select(s => _dataSourceServiceModel with { Source = s }).ToList());
+        sut.TestId.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(Source.Gias, "2001-02-03T04:05:06Z", "some.user@education.gov.uk", "All information was",
+        "All information was updated by some.user@education.gov.uk on 03 Feb 2001")]
+    [InlineData(Source.FiatDb, "2019-08-07T06:05:43Z", null, "School contacts",
+        "School contacts taken from Find information about schools and trusts on 07 Aug 2019")]
+    [InlineData((Source)100, "2025-07-07", null, "Miscellaneous information",
+        "Miscellaneous information taken from Unknown on 07 Jul 2025")]
+    [InlineData(Source.Mis, null, null, "Some other information",
+        "Some other information taken from State-funded school inspections and outcomes: management information on Unknown")]
+    public void ToString_should_return_expected_string_for_single_data_source(Source source, string? lastUpdatedString,
+        string? updatedBy, string dataField, string expected)
+    {
+        var sut = new DataSourceListEntry(_dataSourceServiceModel with
+        {
+            Source = source, LastUpdated = lastUpdatedString is null ? null : DateTime.Parse(lastUpdatedString),
+            UpdatedBy = updatedBy
+        }, dataField);
+
+        sut.ToString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ToString_should_return_expected_string_for_two_data_sources()
+    {
+        List<DataSourceServiceModel> dataSources =
+        [
+            _dataSourceServiceModel with
+            {
+                Source = Source.ExploreEducationStatistics,
+                LastUpdated = DateTime.Parse("2025-07-07")
+            },
+            _dataSourceServiceModel with
+            {
+                Source = Source.FiatDb,
+                LastUpdated = DateTime.Parse("2025-07-01")
+            }
+        ];
+        var sut = new DataSourceListEntry(dataSources, "Information from two sources");
+
+        sut.ToString().Should()
+            .Be(
+                "Information from two sources taken from Explore education statistics on 07 Jul 2025 and Find information about schools and trusts on 01 Jul 2025");
+    }
+
+    [Fact]
+    public void ToString_should_return_expected_string_for_three_data_sources()
+    {
+        List<DataSourceServiceModel> dataSources =
+        [
+            _dataSourceServiceModel with
+            {
+                Source = Source.ExploreEducationStatistics,
+                LastUpdated = DateTime.Parse("2025-07-07")
+            },
+            _dataSourceServiceModel with
+            {
+                Source = Source.FiatDb,
+                LastUpdated = DateTime.Parse("2025-07-01")
+            },
+            _dataSourceServiceModel with
+            {
+                Source = Source.Gias,
+                LastUpdated = DateTime.Parse("2025-07-03")
+            }
+        ];
+        var sut = new DataSourceListEntry(dataSources, "Information from three sources");
+
+        sut.ToString().Should()
+            .Be(
+                "Information from three sources taken from Explore education statistics on 07 Jul 2025, Find information about schools and trusts on 01 Jul 2025, and Get information about schools on 03 Jul 2025");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
@@ -163,7 +163,7 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
 
         await Sut.OnGetAsync();
 
-        Sut.DataSourcesPerPage[0].DataSources[0].DataSource.Should().Be(
+        Sut.DataSourcesPerPage[0].DataSources[0].DataSources[0].Should().Be(
             new DataSourceServiceModel(Source.FiatDb,
                 _trustRelationshipManager.LastModifiedAtTime,
                 null,
@@ -179,7 +179,7 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
 
         await Sut.OnGetAsync();
 
-        Sut.DataSourcesPerPage[0].DataSources[1].DataSource.Should().Be(
+        Sut.DataSourcesPerPage[0].DataSources[1].DataSources[0].Should().Be(
             new DataSourceServiceModel(Source.FiatDb,
                 _sfsoLead.LastModifiedAtTime,
                 null,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
@@ -30,6 +30,7 @@ public class DataSourceServiceTests
         { Source.Gias, GetDummyDataSource(Source.Gias, UpdateFrequency.Daily) },
         { Source.ManageFreeSchoolProjects, GetDummyDataSource(Source.ManageFreeSchoolProjects, UpdateFrequency.Daily) },
         { Source.Mis, GetDummyDataSource(Source.Mis, UpdateFrequency.Monthly) },
+        { Source.MisFurtherEducation, GetDummyDataSource(Source.MisFurtherEducation, UpdateFrequency.Monthly) },
         { Source.Mstr, GetDummyDataSource(Source.Mstr, UpdateFrequency.Daily) },
         { Source.Prepare, GetDummyDataSource(Source.Prepare, UpdateFrequency.Daily) }
     };
@@ -44,7 +45,8 @@ public class DataSourceServiceTests
 
         Source[] supportedAcademiesDbSources =
         [
-            Source.Cdm, Source.Complete, Source.Gias, Source.ManageFreeSchoolProjects, Source.Mis, Source.Mstr,
+            Source.Cdm, Source.Complete, Source.Gias, Source.ManageFreeSchoolProjects, Source.Mis,
+            Source.MisFurtherEducation, Source.Mstr,
             Source.Prepare
         ];
 
@@ -78,6 +80,7 @@ public class DataSourceServiceTests
     [InlineData(Source.ExploreEducationStatistics, UpdateFrequency.Annually)]
     [InlineData(Source.Gias, UpdateFrequency.Daily)]
     [InlineData(Source.Mis, UpdateFrequency.Monthly)]
+    [InlineData(Source.MisFurtherEducation, UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, UpdateFrequency.Daily)]
     public async Task GetAsync_cached_should_return_cached_result(Source source, UpdateFrequency updateFrequency)
     {
@@ -96,6 +99,7 @@ public class DataSourceServiceTests
     [InlineData(Source.Gias, UpdateFrequency.Daily)]
     [InlineData(Source.ManageFreeSchoolProjects, UpdateFrequency.Daily)]
     [InlineData(Source.Mis, UpdateFrequency.Monthly)]
+    [InlineData(Source.MisFurtherEducation, UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, UpdateFrequency.Daily)]
     [InlineData(Source.Prepare, UpdateFrequency.Daily)]
     public async Task GetAsync_uncached_should_call_dataSourceRepository(Source source, UpdateFrequency updateFrequency)
@@ -119,6 +123,7 @@ public class DataSourceServiceTests
     [InlineData(Source.Gias)]
     [InlineData(Source.ManageFreeSchoolProjects)]
     [InlineData(Source.Mis)]
+    [InlineData(Source.MisFurtherEducation)]
     [InlineData(Source.Mstr)]
     [InlineData(Source.Prepare)]
     public async Task GetAsync_uncached_should_call_academiesDbDataSourceRepository(Source source)
@@ -136,6 +141,7 @@ public class DataSourceServiceTests
     [InlineData(Source.Gias, UpdateFrequency.Daily)]
     [InlineData(Source.ManageFreeSchoolProjects, UpdateFrequency.Daily)]
     [InlineData(Source.Mis, UpdateFrequency.Monthly)]
+    [InlineData(Source.MisFurtherEducation, UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, UpdateFrequency.Daily)]
     [InlineData(Source.Prepare, UpdateFrequency.Daily)]
     public async Task GetAsync_uncached_should_cache_result(Source source, UpdateFrequency updateFrequency)


### PR DESCRIPTION
This PR refactors how data sources are presented to the user to allow for a piece of information to be derived from multiple sources in the "Where this information came from" section on a page.

> [!Note]
> See [User Story 205477](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205477): Build: Ungraded inspections data for a school/academy

## Changes

- A new `MisFurtherEducation` data source has been introduced in anticipation of the upcoming 'single headline grades' page for a school. It is displayed to the user as **Further education and skills inspections and outcomes: management information**.
- A `DataSourceListEntry` has been significantly refactored:
  - It is now responsible for generating the entire user-facing string, which can be done by calling the `ToString` method.
  - It is now constructed using a `List<DataSourceServiceModel>`, although an alternative constructor that takes a single `DataSourceServiceModel` and wraps it in a list is provided for backwards compatibility.
  - The `LastUpdatedText`, `UpdatedByText`, and `Name` properties are now `GetLastUpdatedText`, `GetUpdatedByText`, and `GetName` methods respectively, each of which accepts a `DataSourceServiceModel`
  - The `TestId` property now interpolates all of the data sources into the output to ensure uniqueness

## Screenshots of UI changes

### Before

### After

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
