### PR TITLE
[205477] Get Ofsted data for a single school

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/OfstedRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/OfstedRepository.cs
@@ -39,6 +39,19 @@ public class OfstedRepository(IAcademiesDbContext academiesDbContext, ILogger<Ac
         return academyOfsteds;
     }
 
+    public async Task<OfstedInspectionHistorySummary> GetOfstedInspectionHistorySummaryAsync(int urn)
+    {
+        var urnString = urn.ToString();
+        var rating = (await GetOfstedRatings([urnString]))[urnString];
+
+        var currentFullInspection =
+            new OfstedFullInspectionSummary(rating.Current.InspectionDate, rating.Current.OverallEffectiveness);
+        var previousFullInspection =
+            new OfstedFullInspectionSummary(rating.Previous.InspectionDate, rating.Previous.OverallEffectiveness);
+
+        return new OfstedInspectionHistorySummary(currentFullInspection, previousFullInspection);
+    }
+
     public async Task<OfstedShortInspection> GetOfstedShortInspectionAsync(int urn)
     {
         return await academiesDbContext.MisMstrEstablishmentsFiat.Where(est => est.Urn == urn).Select(est =>

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/OfstedRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/OfstedRepository.cs
@@ -39,6 +39,13 @@ public class OfstedRepository(IAcademiesDbContext academiesDbContext, ILogger<Ac
         return academyOfsteds;
     }
 
+    public async Task<OfstedShortInspection> GetOfstedShortInspectionAsync(int urn)
+    {
+        return await academiesDbContext.MisMstrEstablishmentsFiat.Where(est => est.Urn == urn).Select(est =>
+            new OfstedShortInspection(est.DateOfLatestSection8Inspection.ParseAsNullableDate(),
+                est.Section8InspectionOverallOutcome)).FirstOrDefaultAsync() ?? OfstedShortInspection.Unknown;
+    }
+
     private async Task<Dictionary<string, AcademyOfstedRatings>> GetOfstedRatings(string[] urns)
     {
         // First pass at getting ofsted ratings from the db
@@ -66,7 +73,8 @@ public class OfstedRepository(IAcademiesDbContext academiesDbContext, ILogger<Ac
                 logger.LogError(
                     "URN {Urn} was not found in Mis.Establishments or Mis.FurtherEducationEstablishments. This indicates a data integrity issue with the Ofsted data in Academies Db.",
                     urn);
-                allOfstedRatings.Add(urn, new AcademyOfstedRatings(int.Parse(urn), OfstedRating.Unknown, OfstedRating.Unknown, "none"));
+                allOfstedRatings.Add(urn,
+                    new AcademyOfstedRatings(int.Parse(urn), OfstedRating.Unknown, OfstedRating.Unknown, "none"));
                 continue;
             }
 

--- a/DfE.FindInformationAcademiesTrusts.Data/OfstedFullInspectionSummary.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/OfstedFullInspectionSummary.cs
@@ -1,0 +1,6 @@
+namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public record OfstedFullInspectionSummary(DateTime? InspectionDate, OfstedRatingScore InspectionOutcome)
+{
+    public static readonly OfstedFullInspectionSummary Unknown = new(null, OfstedRatingScore.Unknown);
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/OfstedInspectionHistorySummary.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/OfstedInspectionHistorySummary.cs
@@ -1,0 +1,10 @@
+namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public record OfstedInspectionHistorySummary(
+    OfstedFullInspectionSummary CurrentInspection,
+    OfstedFullInspectionSummary PreviousInspection)
+{
+    public static readonly OfstedInspectionHistorySummary Unknown = new(
+        OfstedFullInspectionSummary.Unknown,
+        OfstedFullInspectionSummary.Unknown);
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/OfstedShortInspection.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/OfstedShortInspection.cs
@@ -1,0 +1,6 @@
+namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public record OfstedShortInspection(DateTime? InspectionDate, string? InspectionOutcome)
+{
+    public static readonly OfstedShortInspection Unknown = new(null, null);
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Ofsted/IOfstedRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Ofsted/IOfstedRepository.cs
@@ -3,5 +3,6 @@ namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 public interface IOfstedRepository
 {
     Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid);
+    Task<OfstedInspectionHistorySummary> GetOfstedInspectionHistorySummaryAsync(int urn);
     Task<OfstedShortInspection> GetOfstedShortInspectionAsync(int urn);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Ofsted/IOfstedRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Ofsted/IOfstedRepository.cs
@@ -3,4 +3,5 @@ namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 public interface IOfstedRepository
 {
     Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid);
+    Task<OfstedShortInspection> GetOfstedShortInspectionAsync(int urn);
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/School/OfstedHeadlineGradesServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/OfstedHeadlineGradesServiceModel.cs
@@ -1,0 +1,11 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.School;
+
+public record OfstedHeadlineGradesServiceModel(
+    OfstedShortInspection ShortInspection,
+    OfstedFullInspectionSummary CurrentInspection,
+    OfstedFullInspectionSummary PreviousInspection)
+{
+    public bool HasRecentShortInspection => ShortInspection.InspectionDate > CurrentInspection.InspectionDate;
+}

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -10,9 +11,14 @@ public interface ISchoolService
     Task<bool> IsPartOfFederationAsync(int urn);
 
     Task<SchoolReferenceNumbersServiceModel> GetReferenceNumbersAsync(int urn);
+
+    Task<OfstedHeadlineGradesServiceModel> GetOfstedHeadlineGrades(int urn);
 }
 
-public class SchoolService(IMemoryCache memoryCache, ISchoolRepository schoolRepository) : ISchoolService
+public class SchoolService(
+    IMemoryCache memoryCache,
+    ISchoolRepository schoolRepository,
+    IOfstedRepository ofstedRepository) : ISchoolService
 {
     public async Task<bool> IsPartOfFederationAsync(int urn)
     {
@@ -55,5 +61,14 @@ public class SchoolService(IMemoryCache memoryCache, ISchoolRepository schoolRep
             : null;
 
         return new SchoolReferenceNumbersServiceModel(urn, laestab, referenceNumbers.Ukprn);
+    }
+
+    public async Task<OfstedHeadlineGradesServiceModel> GetOfstedHeadlineGrades(int urn)
+    {
+        var shortInspection = await ofstedRepository.GetOfstedShortInspectionAsync(urn);
+        var inspectionHistorySummary = await ofstedRepository.GetOfstedInspectionHistorySummaryAsync(urn);
+
+        return new OfstedHeadlineGradesServiceModel(shortInspection, inspectionHistorySummary.CurrentInspection,
+            inspectionHistorySummary.PreviousInspection);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
@@ -844,6 +844,153 @@ public class OfstedRepositoryTests
 
     [Fact]
     public async Task
+        GetOfstedInspectionHistorySummaryAsync_when_no_establishment_with_urn_exists_then_returns_Unknown_OfsteadInspectionHistorySummary()
+    {
+        var result = await _sut.GetOfstedInspectionHistorySummaryAsync(123456);
+
+        result.Should().BeEquivalentTo(OfstedInspectionHistorySummary.Unknown);
+    }
+
+    [Theory]
+    [InlineData(
+        "01/01/2024",
+        "2",
+        OfstedRatingScore.Good,
+        "01/01/2014",
+        "3",
+        OfstedRatingScore.RequiresImprovement)]
+    [InlineData(
+        "12/12/2023",
+        "3",
+        OfstedRatingScore.RequiresImprovement,
+        "12/12/2013",
+        "4",
+        OfstedRatingScore.Inadequate)]
+    public async Task
+        GetOfstedInspectionHistorySummaryAsync_when_establishment_exists_then_returns_OfsteadInspectionHistorySummary_with_correct_data(
+            string currentInspectionDate,
+            string currentInspectionOutcome,
+            OfstedRatingScore expectedCurrentInspectionOutcome,
+            string previousInspectionDate,
+            string previousInspectionOutcome,
+            OfstedRatingScore expectedPreviousInspectionOutcome)
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                InspectionStartDate = currentInspectionDate,
+                OverallEffectiveness = currentInspectionOutcome,
+                PreviousInspectionStartDate = previousInspectionDate,
+                PreviousFullInspectionOverallEffectiveness = previousInspectionOutcome
+            },
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 987654,
+                InspectionStartDate = "06/06/2023",
+                OverallEffectiveness = "Outstanding",
+                PreviousInspectionStartDate = "06/06/2013",
+                PreviousFullInspectionOverallEffectiveness = "Outstanding"
+            }
+        ]);
+
+        var result = await _sut.GetOfstedInspectionHistorySummaryAsync(123456);
+
+        result.CurrentInspection.InspectionDate.Should().NotBeNull();
+        result.CurrentInspection.InspectionDate.Should().Be(DateTime.Parse(currentInspectionDate));
+        result.CurrentInspection.InspectionOutcome.Should().Be(expectedCurrentInspectionOutcome);
+
+        result.PreviousInspection.InspectionDate.Should().NotBeNull();
+        result.PreviousInspection.InspectionDate.Should().Be(DateTime.Parse(previousInspectionDate));
+        result.PreviousInspection.InspectionOutcome.Should().Be(expectedPreviousInspectionOutcome);
+    }
+
+    [Fact]
+    public async Task
+        GetOfstedInspectionHistorySummaryAsync_when_current_inspection_date_is_missing_then_CurrentInspection_has_null_InspectionDate()
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                InspectionStartDate = null,
+                OverallEffectiveness = "1",
+                PreviousInspectionStartDate = "01/01/2012",
+                PreviousFullInspectionOverallEffectiveness = "1"
+            }
+        ]);
+
+        var result = await _sut.GetOfstedInspectionHistorySummaryAsync(123456);
+
+        result.CurrentInspection.InspectionDate.Should().BeNull();
+        result.PreviousInspection.InspectionDate.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task
+        GetOfstedInspectionHistorySummaryAsync_when_previous_inspection_date_is_missing_then_PreviousInspection_has_null_InspectionDate()
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                InspectionStartDate = "01/01/2022",
+                OverallEffectiveness = "1",
+                PreviousInspectionStartDate = null,
+                PreviousFullInspectionOverallEffectiveness = "1"
+            }
+        ]);
+
+        var result = await _sut.GetOfstedInspectionHistorySummaryAsync(123456);
+
+        result.CurrentInspection.InspectionDate.Should().NotBeNull();
+        result.PreviousInspection.InspectionDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task
+        GetOfstedInspectionHistorySummaryAsync_when_current_overall_effectiveness_is_missing_then_CurrentInspection_has_NotInspected_InspectionOutcome()
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                InspectionStartDate = "01/01/2022",
+                OverallEffectiveness = null,
+                PreviousInspectionStartDate = "01/01/2012",
+                PreviousFullInspectionOverallEffectiveness = "1"
+            }
+        ]);
+
+        var result = await _sut.GetOfstedInspectionHistorySummaryAsync(123456);
+
+        result.CurrentInspection.InspectionOutcome.Should().Be(OfstedRatingScore.NotInspected);
+        result.PreviousInspection.InspectionOutcome.Should().NotBe(OfstedRatingScore.NotInspected);
+    }
+
+    [Fact]
+    public async Task
+        GetOfstedInspectionHistorySummaryAsync_when_previous_overall_effectiveness_is_missing_then_PreviousInspection_has_NotInspected_InspectionOutcome()
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                InspectionStartDate = "01/01/2022",
+                OverallEffectiveness = "1",
+                PreviousInspectionStartDate = "01/01/2012",
+                PreviousFullInspectionOverallEffectiveness = null
+            }
+        ]);
+
+        var result = await _sut.GetOfstedInspectionHistorySummaryAsync(123456);
+
+        result.CurrentInspection.InspectionOutcome.Should().NotBe(OfstedRatingScore.NotInspected);
+        result.PreviousInspection.InspectionOutcome.Should().Be(OfstedRatingScore.NotInspected);
+    }
+
+    [Fact]
+    public async Task
         GetOfstedShortInspectionAsync_when_no_establishment_with_urn_exists_then_returns_Unknown_ShortInspection()
     {
         var result = await _sut.GetOfstedShortInspectionAsync(123456);

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
@@ -841,4 +841,79 @@ public class OfstedRepositoryTests
             }
         }
     }
+
+    [Fact]
+    public async Task
+        GetOfstedShortInspectionAsync_when_no_establishment_with_urn_exists_then_returns_Unknown_ShortInspection()
+    {
+        var result = await _sut.GetOfstedShortInspectionAsync(123456);
+
+        result.Should().BeEquivalentTo(OfstedShortInspection.Unknown);
+    }
+
+    [Theory]
+    [InlineData("01/01/2025", "School remains Good")]
+    [InlineData("12/12/2024", "Improved significantly")]
+    public async Task
+        GetOfstedShortInspectionAsync_when_establishment_exists_then_returns_ShortInspection_with_correct_data(
+            string inspectionDate, string inspectionOutcome)
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                DateOfLatestSection8Inspection = inspectionDate,
+                Section8InspectionOverallOutcome = inspectionOutcome
+            },
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 987654,
+                DateOfLatestSection8Inspection = "06/06/2023",
+                Section8InspectionOverallOutcome = "School remains Outstanding"
+            }
+        ]);
+
+        var result = await _sut.GetOfstedShortInspectionAsync(123456);
+
+        result.InspectionDate.Should().NotBeNull();
+        result.InspectionDate!.Should().Be(DateTime.Parse(inspectionDate));
+        result.InspectionOutcome.Should().NotBeNull();
+        result.InspectionOutcome!.Should().Be(inspectionOutcome);
+    }
+
+    [Fact]
+    public async Task
+        GetOfstedShortInspectionAsync_when_inspection_date_is_missing_then_ShortInspection_has_null_InspectionDate()
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                DateOfLatestSection8Inspection = null,
+                Section8InspectionOverallOutcome = "School remains Outstanding"
+            }
+        ]);
+
+        var result = await _sut.GetOfstedShortInspectionAsync(123456);
+
+        result.InspectionDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task
+        GetOfstedShortInspectionAsync_when_inspection_outcome_is_missing_then_ShortInspection_has_null_InspectionOutcome()
+    {
+        _mockAcademiesDbContext.MisMstrEstablishmentFiat.AddRange([
+            new MisMstrEstablishmentFiat
+            {
+                Urn = 123456,
+                DateOfLatestSection8Inspection = "01/01/2025",
+                Section8InspectionOverallOutcome = null
+            }
+        ]);
+
+        var result = await _sut.GetOfstedShortInspectionAsync(123456);
+
+        result.InspectionOutcome.Should().BeNull();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/OfstedHeadlineGradesServiceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/OfstedHeadlineGradesServiceModelTests.cs
@@ -1,0 +1,47 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
+
+public class OfstedHeadlineGradesServiceModelTests
+{
+    [Fact]
+    public void
+        HasRecentShortInspection_returns_true_when_ShortInspection_InspectionDate_is_after_CurrentInspection_InspectionDate()
+    {
+        new OfstedHeadlineGradesServiceModel(
+                new OfstedShortInspection(new DateTime(2022, 1, 1), "School remains Good"),
+                new OfstedFullInspectionSummary(new DateTime(2021, 1, 1), OfstedRatingScore.Good),
+                new OfstedFullInspectionSummary(new DateTime(2011, 1, 1), OfstedRatingScore.RequiresImprovement))
+            .HasRecentShortInspection.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(2021)]
+    [InlineData(2020)]
+    public void
+        HasRecentShortInspection_returns_false_when_ShortInspection_InspectionDate_is_not_after_CurrentInspection_InspectionDate(int year)
+    {
+        new OfstedHeadlineGradesServiceModel(
+                new OfstedShortInspection(new DateTime(year, 1, 1), "School remains Good"),
+                new OfstedFullInspectionSummary(new DateTime(2021, 1, 1), OfstedRatingScore.Good),
+                new OfstedFullInspectionSummary(new DateTime(2011, 1, 1), OfstedRatingScore.RequiresImprovement))
+            .HasRecentShortInspection.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasRecentShortInspection_returns_false_when_ShortInspection_InspectionDate_is_null()
+    {
+        new OfstedHeadlineGradesServiceModel(
+                OfstedShortInspection.Unknown,
+                new OfstedFullInspectionSummary(new DateTime(2021, 1, 1), OfstedRatingScore.Good),
+                new OfstedFullInspectionSummary(new DateTime(2011, 1, 1), OfstedRatingScore.RequiresImprovement))
+            .HasRecentShortInspection.Should().BeFalse();
+
+        new OfstedHeadlineGradesServiceModel(
+                OfstedShortInspection.Unknown,
+                OfstedFullInspectionSummary.Unknown,
+                OfstedFullInspectionSummary.Unknown)
+            .HasRecentShortInspection.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
This PR implements the repository and service layer for getting Ofsted data for a school or academy.

> [!Note]
> See [User Story 205477](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205477): Build: Ungraded inspections data for a school/academy

## Changes

- The `OfstedRepository` class has had new methods added:
  - `GetOfstedShortInspectionAsync`, which takes in a URN and returns an `OfstedShortInspection` record containing the inspection date and the outcome.
  - `GetOfstedInspectionHistorySummaryAsync`, which takes in a URN and returns an `OfstedInspectionHistorySummary` record containing the inspection date and the outcome for both the current and previous full inspections.
- The `SchoolService` class now has a `GetOfstedHeadlineGrades` method, which gets the short inspection, the current inspection, and the previous inspection, and combines them into an `OfstedHeadlineGradesServiceModel` record.

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
