### PR TITLE
[205477] Add 'Single headline grades' page for a school or academy

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
@@ -13,6 +13,7 @@ public interface IOtherServicesLinkBuilder
 
     string? FinancialBenchmarkingInsightsToolListingLink(string? companiesHouseNumber);
     string FinancialBenchmarkingLinkForSchool(int urn);
+    string OfstedReportLinkForSchool(int urn);
 }
 
 public class OtherServicesLinkBuilder : IOtherServicesLinkBuilder
@@ -29,6 +30,8 @@ public class OtherServicesLinkBuilder : IOtherServicesLinkBuilder
         "https://www.find-school-performance-data.service.gov.uk";
 
     private const string SharepointBaseUrl = "https://educationgovuk.sharepoint.com";
+
+    private const string OfstedReportsBaseUrl = "https://reports.ofsted.gov.uk";
 
     public string GetInformationAboutSchoolsListingLinkForTrust(string trustUid)
     {
@@ -79,5 +82,10 @@ public class OtherServicesLinkBuilder : IOtherServicesLinkBuilder
     {
         return
             $"{SharepointBaseUrl}/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q={groupId}&v=%2Fsearch";
+    }
+
+    public string OfstedReportLinkForSchool(int urn)
+    {
+        return $"{OfstedReportsBaseUrl}/inspection-reports/find-inspection-report/provider/ELS/{urn}";
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/OfstedAreaModel.cs
@@ -1,0 +1,80 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Export;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
+
+public class OfstedAreaModel(
+    ISchoolService schoolService,
+    ISchoolOverviewDetailsService schoolOverviewDetailsService,
+    ITrustService trustService,
+    IDataSourceService dataSourceService,
+    IOfstedSchoolDataExportService ofstedSchoolDataExportService,
+    IDateTimeProvider dateTimeProvider,
+    IOtherServicesLinkBuilder otherServicesLinkBuilder,
+    ISchoolNavMenu schoolNavMenu)
+    : SchoolAreaModel(schoolService, trustService, schoolNavMenu)
+{
+    private readonly ISchoolService _schoolService = schoolService;
+
+    public const string PageName = "Ofsted";
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
+
+    public DateTime? DateJoinedTrust { get; set; }
+    public string OfstedReportUrl { get; set; } = null!;
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+        if (pageResult is NotFoundResult) return pageResult;
+
+        var schoolOverview = await schoolOverviewDetailsService.GetSchoolOverviewDetailsAsync(Urn, SchoolCategory);
+        if (schoolOverview.DateJoinedTrust is not null)
+        {
+            DateJoinedTrust = schoolOverview.DateJoinedTrust.Value.ToDateTime(new TimeOnly());
+        }
+
+        OfstedReportUrl = otherServicesLinkBuilder.OfstedReportLinkForSchool(Urn);
+
+        List<DataSourceServiceModel> dataSources =
+        [
+            await dataSourceService.GetAsync(Source.Mis),
+            await dataSourceService.GetAsync(Source.MisFurtherEducation)
+        ];
+
+        DataSourcesPerPage =
+        [
+            new DataSourcePageListEntry(SingleHeadlineGradesModel.SubPageName, [
+                new DataSourceListEntry(dataSources, "Single headline grades were"),
+                new DataSourceListEntry(dataSources, "All inspection dates were")
+            ])
+        ];
+
+        return Page();
+    }
+
+    public virtual async Task<IActionResult> OnGetExportAsync(int urn)
+    {
+        var schoolSummary = await _schoolService.GetSchoolSummaryAsync(urn);
+
+        if (schoolSummary == null)
+        {
+            return new NotFoundResult();
+        }
+
+        var sanitisedSchoolName =
+            string.Concat(schoolSummary.Name.Where(c => !Path.GetInvalidFileNameChars().Contains(c))).Trim();
+
+        var fileContents = await ofstedSchoolDataExportService.BuildAsync(urn);
+        var fileName = $"Ofsted-{sanitisedSchoolName}-{dateTimeProvider.Now:yyyy-MM-dd}.xlsx";
+        var contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+        return File(fileContents, contentType, fileName);
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
@@ -1,0 +1,100 @@
+@page
+@using DfE.FindInformationAcademiesTrusts.Extensions
+@model SingleHeadlineGradesModel
+
+@{
+    Layout = "_SchoolLayout";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" data-testid="subpage-header">
+            @Model.PageMetadata.SubPageName
+        </h3>
+
+        @if (Model.DateJoinedTrust is not null)
+        {
+            <p class="govuk-body">This academy joined the trust on
+                <strong>@Model.DateJoinedTrust.ShowDateStringOrReplaceWithText()</strong>.</p>
+        }
+
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    Why a single headline grade might not be available
+                </span>
+            </summary>
+
+            <div class="govuk-details__text">
+                <p class="govuk-body">
+                    Single headline grades stopped being awarded by Ofsted on
+                    <strong>2 September 2024</strong>.
+                </p>
+                <p class="govuk-body">Inspections completed after this date are broken down by category.</p>
+                <p class="govuk-body">You can see these on the ‘Current ratings’ and ‘Previous ratings’ pages.</p>
+            </div>
+        </details>
+
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    Why short inspection data might not be available
+                </span>
+            </summary>
+
+            <div class="govuk-details__text">
+                <p class="govuk-body">A grade and date of a short inspection may not be available, when a full
+                    inspection has followed it.</p>
+                <p class="govuk-body">The data can be found in the school's Ofsted inspection reports.</p>
+            </div>
+        </details>
+
+        <table class="govuk-table govuk-!-margin-bottom-0">
+            <caption class="govuk-table__caption govuk-visually-hidden">Grades and inspection dates</caption>
+
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">
+                    <span class="govuk-visually-hidden">Data type</span>
+                </th>
+                <th scope="col" class="govuk-table__header">Date of inspection</th>
+                <th scope="col" class="govuk-table__header">Grade</th>
+            </tr>
+            </thead>
+
+            <tbody class="govuk-table__body">
+            @if (Model.HeadlineGrades.HasRecentShortInspection)
+            {
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__cell">Recent short inspection</th>
+                    <td class="govuk-table__cell">@Model.HeadlineGrades.ShortInspection.InspectionDate.ShowDateStringOrReplaceWithText("Not available")</td>
+                    <td class="govuk-table__cell">@Model.HeadlineGrades.ShortInspection.InspectionOutcome</td>
+                </tr>
+            }
+
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__cell">Current full inspection</th>
+                <td class="govuk-table__cell">@Model.HeadlineGrades.CurrentInspection.InspectionDate.ShowDateStringOrReplaceWithText("Not available")</td>
+                <td class="govuk-table__cell">@Model.HeadlineGrades.CurrentInspection.InspectionOutcome.ToDisplayString(true)</td>
+            </tr>
+
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__cell">Previous full inspection</th>
+                <td class="govuk-table__cell">@Model.HeadlineGrades.PreviousInspection.InspectionDate.ShowDateStringOrReplaceWithText("Not available")</td>
+                <td class="govuk-table__cell">@Model.HeadlineGrades.PreviousInspection.InspectionOutcome.ToDisplayString(false)</td>
+            </tr>
+            </tbody>
+        </table>
+
+        <hr class="govuk-section-break govuk-section-break--m">
+
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl">See the inspection reports at Ofsted</a>.</p>
+
+        <hr class="govuk-section-break govuk-section-break--m">
+
+        <a asp-page-handler="Export" asp-route-urn="@Model.Urn" draggable="false" class="govuk-button govuk-button--secondary"
+           data-module="govuk-button" data-govuk-button-init="">
+            Download all Ofsted data
+        </a>
+    </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml.cs
@@ -1,0 +1,36 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Export;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
+
+public class SingleHeadlineGradesModel(
+    ISchoolService schoolService,
+    ISchoolOverviewDetailsService schoolOverviewDetailsService,
+    ITrustService trustService,
+    IDataSourceService dataSourceService,
+    IOfstedSchoolDataExportService ofstedSchoolDataExportService,
+    IDateTimeProvider dateTimeProvider,
+    IOtherServicesLinkBuilder otherServicesLinkBuilder,
+    ISchoolNavMenu schoolNavMenu) : OfstedAreaModel(schoolService, schoolOverviewDetailsService, trustService,
+    dataSourceService, ofstedSchoolDataExportService, dateTimeProvider, otherServicesLinkBuilder, schoolNavMenu)
+{
+    private readonly ISchoolService _schoolService = schoolService;
+    public const string SubPageName = "Single headline grades";
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
+    public OfstedHeadlineGradesServiceModel HeadlineGrades { get; set; } = null!;
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+        if (pageResult is NotFoundResult) return pageResult;
+
+        HeadlineGrades = await _schoolService.GetOfstedHeadlineGrades(Urn);
+
+        return pageResult;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
@@ -2,6 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.NavMenu;
 using Microsoft.FeatureManagement;
@@ -26,7 +27,9 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
         [
             GetServiceNavLinkTo<OverviewAreaModel>(OverviewAreaModel.PageName, "/Schools/Overview/Details",
                 activePage),
-            GetServiceNavLinkTo<ContactsAreaModel>(ContactsAreaModel.PageName, contactLink, activePage)
+            GetServiceNavLinkTo<ContactsAreaModel>(ContactsAreaModel.PageName, contactLink, activePage),
+            GetServiceNavLinkTo<OfstedAreaModel>(OfstedAreaModel.PageName, "/Schools/Ofsted/SingleHeadlineGrades",
+                activePage)
         ];
     }
 
@@ -46,6 +49,7 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
         {
             OverviewAreaModel => BuildLinksForOverviewPage(activePage),
             ContactsAreaModel => await BuildLinksForContactsPageAsync(activePage),
+            OfstedAreaModel => BuildLinksForOfstedPage(activePage),
             _ => throw new ArgumentOutOfRangeException(nameof(activePage), activePage, "Page type is not supported.")
         };
     }
@@ -107,6 +111,15 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
                 inSchoolNavLink
             ]
             : [inSchoolNavLink];
+    }
+
+    private static NavLink[] BuildLinksForOfstedPage(ISchoolAreaModel activePage)
+    {
+        return
+        [
+            GetSubNavLinkTo<SingleHeadlineGradesModel>(OfstedAreaModel.PageName, SingleHeadlineGradesModel.SubPageName,
+                "/Schools/Ofsted/SingleHeadlineGrades", activePage, "ofsted-single-headline-grades-subnav")
+        ];
     }
 
     private static NavLink GetSubNavLinkTo<T>(string serviceName, string linkDisplayText, string aspPage,

--- a/DfE.FindInformationAcademiesTrusts/Services/Export/ExportBuilder.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/ExportBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using ClosedXML.Excel;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.Services.School;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.Export
@@ -11,6 +13,7 @@ namespace DfE.FindInformationAcademiesTrusts.Services.Export
         public IXLWorksheet Worksheet { get; set; }
 
         public readonly int TrustRows = 3;
+        public readonly int SchoolRows = 3;
         public readonly int HeaderRows = 1;
 
         public int CurrentRow { get; set; }
@@ -35,6 +38,23 @@ namespace DfE.FindInformationAcademiesTrusts.Services.Export
             Worksheet.Cell(2, 1).Value = trustSummary.Type;
 
             CurrentRow += TrustRows;
+
+            return this;
+        }
+
+        public ExportBuilder WriteSchoolInformation(SchoolOverviewServiceModel school, SchoolCategory category)
+        {
+            Worksheet.Cell(1, 1).Value = school.Name;
+            Worksheet.Row(1).Style.Font.Bold = true;
+
+            Worksheet.Cell(2, 1).Value = category switch
+            {
+                SchoolCategory.LaMaintainedSchool => "Not part of a trust",
+                SchoolCategory.Academy => $"Joined trust on {school.DateJoinedTrust:dd/MM/yyyy}",
+                _ => throw new ArgumentOutOfRangeException(nameof(category))
+            };
+
+            CurrentRow += SchoolRows;
 
             return this;
         }

--- a/DfE.FindInformationAcademiesTrusts/Services/Export/ExportColumns.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/ExportColumns.cs
@@ -39,6 +39,13 @@
             CategoryOfConcern = 22
         }
 
+        public enum OfstedSchoolColumns
+        {
+            InspectionType = 1,
+            DateOfInspection = 2,
+            Grade = 3,
+        }
+
         public enum AcademyColumns
         {
             SchoolName = 1,

--- a/DfE.FindInformationAcademiesTrusts/Services/Export/OfstedSchoolDataExportService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/OfstedSchoolDataExportService.cs
@@ -1,0 +1,69 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Exceptions;
+using DfE.FindInformationAcademiesTrusts.Extensions;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.Export;
+
+public interface IOfstedSchoolDataExportService
+{
+    Task<byte[]> BuildAsync(int urn);
+}
+
+public class OfstedSchoolDataExportService(ISchoolService schoolService, ISchoolOverviewDetailsService schoolOverviewDetailsService) : ExportBuilder("Ofsted"), IOfstedSchoolDataExportService
+{
+    private readonly List<string> _headers =
+    [
+        "Inspection type",
+        "Date of inspection",
+        "Grade",
+    ];
+
+    public async Task<byte[]> BuildAsync(int urn)
+    {
+        var schoolDetails = await schoolService.GetSchoolSummaryAsync(urn);
+
+        if (schoolDetails is null)
+        {
+            throw new DataIntegrityException($"School summary not found for URN: {urn}");
+        }
+        
+        var schoolOverview =
+            await schoolOverviewDetailsService.GetSchoolOverviewDetailsAsync(urn, schoolDetails.Category);
+        var headlineGrades = await schoolService.GetOfstedHeadlineGrades(urn);
+        return WriteSchoolInformation(schoolOverview, schoolDetails.Category)
+            .WriteHeaders(_headers)
+            .WriteRows(() => WriteRows(headlineGrades))
+            .Build();
+    }
+    
+    private void WriteRows(OfstedHeadlineGradesServiceModel headlineGrades)
+    {
+        if (headlineGrades.HasRecentShortInspection)
+        {
+            WriteRecentShortInspectionRow(headlineGrades.ShortInspection);
+        }
+        WriteFullInspectionRow(headlineGrades.CurrentInspection, true);
+        WriteFullInspectionRow(headlineGrades.PreviousInspection, false);
+    }
+
+    private void WriteRecentShortInspectionRow(OfstedShortInspection shortInspection)
+    {
+        WriteInspectionRow("Recent short inspection", shortInspection.InspectionDate, shortInspection.InspectionOutcome);
+    }
+
+    private void WriteFullInspectionRow(OfstedFullInspectionSummary fullInspection, bool isCurrent)
+    {
+        var inspectionType = isCurrent ? "Current inspection" : "Previous inspection";
+        WriteInspectionRow(inspectionType, fullInspection.InspectionDate, fullInspection.InspectionOutcome.ToDisplayString(isCurrent));
+    }
+
+    private void WriteInspectionRow(string inspectionType, DateTime? inspectionDate, string? inspectionOutcome)
+    {
+        SetTextCell(ExportColumns.OfstedSchoolColumns.InspectionType, inspectionType);
+        SetDateCell(ExportColumns.OfstedSchoolColumns.DateOfInspection, inspectionDate);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.Grade, inspectionOutcome ?? string.Empty);
+
+        CurrentRow++;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -91,6 +91,7 @@ public static class Dependencies
 
         builder.Services.AddScoped<IPipelineAcademiesExportService, PipelineAcademiesExportService>();
         builder.Services.AddScoped<IOfstedTrustDataExportService, OfstedTrustDataExportService>();
+        builder.Services.AddScoped<IOfstedSchoolDataExportService, OfstedSchoolDataExportService>();
         builder.Services.AddScoped<IAcademiesExportService, AcademiesExportService>();
 
         builder.Services.AddScoped<IOtherServicesLinkBuilder, OtherServicesLinkBuilder>();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
@@ -42,6 +42,7 @@ public static class MockDataSourceService
             Source.Mstr => UpdateFrequency.Daily,
             Source.Prepare => UpdateFrequency.Daily,
             Source.Mis => UpdateFrequency.Monthly,
+            Source.MisFurtherEducation => UpdateFrequency.Monthly,
             Source.ExploreEducationStatistics => UpdateFrequency.Annually,
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
         });
@@ -50,6 +51,8 @@ public static class MockDataSourceService
     public static DataSourceServiceModel Complete { get; } = GetDummyDataSource(Source.Complete);
     public static DataSourceServiceModel Gias { get; } = GetDummyDataSource(Source.Gias);
     public static DataSourceServiceModel Prepare { get; } = GetDummyDataSource(Source.Prepare);
+    public static DataSourceServiceModel Mis { get; } = GetDummyDataSource(Source.Mis);
+    public static DataSourceServiceModel MisFurtherEducation { get; } = GetDummyDataSource(Source.MisFurtherEducation);
 
     public static DataSourceServiceModel Fiat { get; } = new(Source.FiatDb, StaticTime, null, UpdatedBy);
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
@@ -80,8 +80,10 @@ public class OtherServicesLinkBuilderTests
     }
 
     [Theory]
-    [InlineData("TR02345", "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=TR02345&v=%2Fsearch")]
-    [InlineData("", "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=&v=%2Fsearch")]
+    [InlineData("TR02345",
+        "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=TR02345&v=%2Fsearch")]
+    [InlineData("",
+        "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=&v=%2Fsearch")]
     public void SharepointFolderLink_should_return_url_containing_GroupId(string trn, string expected)
     {
         var result =
@@ -96,7 +98,7 @@ public class OtherServicesLinkBuilderTests
     {
         var result = _sut.FinancialBenchmarkingLinkForSchool(111);
         result.Should()
-            .Be($"https://financial-benchmarking-and-insights-tool.education.gov.uk/school/111/spending-and-costs");
+            .Be("https://financial-benchmarking-and-insights-tool.education.gov.uk/school/111/spending-and-costs");
     }
 
 
@@ -105,6 +107,15 @@ public class OtherServicesLinkBuilderTests
     {
         var result = _sut.FindSchoolPerformanceDataListingLink(111);
         result.Should()
-            .Be($"https://www.find-school-performance-data.service.gov.uk/school/111");
+            .Be("https://www.find-school-performance-data.service.gov.uk/school/111");
+    }
+
+    [Theory]
+    [InlineData(123456, "https://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/ELS/123456")]
+    [InlineData(987654, "https://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/ELS/987654")]
+    public void OfstedReportLinkForSchool_should_be_to_the_correct_link(int urn, string expected)
+    {
+        var result = _sut.OfstedReportLinkForSchool(urn);
+        result.Should().Be(expected);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/BaseOfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/BaseOfstedAreaModelTests.cs
@@ -1,0 +1,152 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Export;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Ofsted;
+
+public abstract class BaseOfstedAreaModelTests<T> : BaseSchoolPageTests<T> where T : OfstedAreaModel
+{
+    protected readonly ISchoolOverviewDetailsService MockSchoolOverviewDetailsService =
+        Substitute.For<ISchoolOverviewDetailsService>();
+
+    protected readonly IOfstedSchoolDataExportService MockOfstedSchoolDataExportService =
+        Substitute.For<IOfstedSchoolDataExportService>();
+
+    protected readonly IDateTimeProvider MockDateTimeProvider = Substitute.For<IDateTimeProvider>();
+
+    protected readonly IOtherServicesLinkBuilder MockOtherServicesLinkBuilder =
+        Substitute.For<IOtherServicesLinkBuilder>();
+
+    protected readonly SchoolOverviewServiceModel DummySchoolDetails =
+        new("Cool school", "some street, in a town", "Yorkshire", "Leeds", "Secondary", new AgeRange(11, 18),
+            NurseryProvision.NotRecorded);
+
+    protected BaseOfstedAreaModelTests()
+    {
+        MockSchoolOverviewDetailsService.GetSchoolOverviewDetailsAsync(Arg.Any<int>(), Arg.Any<SchoolCategory>())
+            .Returns(DummySchoolDetails);
+
+        MockOtherServicesLinkBuilder.OfstedReportLinkForSchool(Arg.Any<int>())
+            .Returns(call => $"https://reports.ofsted.gov.uk/test/{call.ArgAt<int>(0)}");
+
+        MockOfstedSchoolDataExportService.BuildAsync(Arg.Any<int>()).Returns("Some Excel data"u8.ToArray());
+
+        MockDateTimeProvider.Now.Returns(new DateTime(2025, 7, 1));
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_PageMetadata_PageName()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.PageName.Should().Be("Ofsted");
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_sets_correct_data_source_list()
+    {
+        await VerifyCorrectDataSources(SchoolUrn);
+
+        MockDataSourceService.ClearReceivedCalls();
+
+        await VerifyCorrectDataSources(AcademyUrn);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_DateJoinedTrust_for_academy()
+    {
+        DummySchoolDetails.DateJoinedTrust = DateOnly.Parse("2011-04-03");
+        Sut.Urn = AcademyUrn;
+
+        _ = await Sut.OnGetAsync();
+
+        Sut.DateJoinedTrust.Should().NotBeNull();
+        Sut.DateJoinedTrust.Should().Be(DateTime.Parse("2011-04-03"));
+    }
+
+    [Fact]
+    public async Task OnGetAsync_does_not_set_DateJoinedTrust_for_school()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.DateJoinedTrust.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task OnGetASync_sets_correct_OfstedReportUrl_for_school()
+    {
+        Sut.Urn = SchoolUrn;
+
+        _ = await Sut.OnGetAsync();
+
+        Sut.OfstedReportUrl.Should().Be($"https://reports.ofsted.gov.uk/test/{SchoolUrn}");
+    }
+
+    [Fact]
+    public async Task OnGetASync_sets_correct_OfstedReportUrl_for_academy()
+    {
+        Sut.Urn = AcademyUrn;
+
+        _ = await Sut.OnGetAsync();
+
+        Sut.OfstedReportUrl.Should().Be($"https://reports.ofsted.gov.uk/test/{AcademyUrn}");
+    }
+
+    [Fact]
+    public async Task OnGetExportAsync_returns_NotFoundResult_for_unknown_urn()
+    {
+        var result = await Sut.OnGetExportAsync(999111);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetExportAsync_returns_expected_file()
+    {
+        var result = await Sut.OnGetExportAsync(SchoolUrn);
+
+        result.Should().BeOfType<FileContentResult>();
+        result.As<FileContentResult>().FileDownloadName.Should().Be("Ofsted-Cool school-2025-07-01.xlsx");
+    }
+
+    [Fact]
+    public async Task OnGetExportAsync_sanitises_school_name_for_file()
+    {
+        MockSchoolService.GetSchoolSummaryAsync(SchoolUrn)
+            .Returns(DummySchoolSummary with { Name = "  School name with invalid characters\0/ " });
+
+        var result = await Sut.OnGetExportAsync(SchoolUrn);
+
+        result.Should().BeOfType<FileContentResult>();
+        result.As<FileContentResult>().FileDownloadName.Should()
+            .Be("Ofsted-School name with invalid characters-2025-07-01.xlsx");
+    }
+
+    private async Task VerifyCorrectDataSources(int urn)
+    {
+        Sut.Urn = urn;
+
+        _ = await Sut.OnGetAsync();
+        await MockDataSourceService.Received(1).GetAsync(Source.Mis);
+        await MockDataSourceService.Received(1).GetAsync(Source.MisFurtherEducation);
+
+        List<DataSourceServiceModel> expectedDataSources =
+        [
+            Mocks.MockDataSourceService.Mis,
+            Mocks.MockDataSourceService.MisFurtherEducation
+        ];
+
+        Sut.DataSourcesPerPage.Should().BeEquivalentTo([
+            new DataSourcePageListEntry("Single headline grades", [
+                new DataSourceListEntry(expectedDataSources, "Single headline grades were"),
+                new DataSourceListEntry(expectedDataSources, "All inspection dates were")
+            ])
+        ]);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/SingleHeadlineGradesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/SingleHeadlineGradesModelTests.cs
@@ -1,0 +1,45 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Ofsted;
+
+public class SingleHeadlineGradesModelTests : BaseOfstedAreaModelTests<SingleHeadlineGradesModel>
+{
+    public SingleHeadlineGradesModelTests()
+    {
+        Sut = new SingleHeadlineGradesModel(MockSchoolService, MockSchoolOverviewDetailsService, MockTrustService,
+                MockDataSourceService, MockOfstedSchoolDataExportService, MockDateTimeProvider,
+                MockOtherServicesLinkBuilder, MockSchoolNavMenu)
+            { Urn = SchoolUrn };
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_PageMetadata_SubPageName()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.SubPageName.Should().Be("Single headline grades");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_correct_HeadlineGrades_data()
+    {
+        var expectedGrades = new OfstedHeadlineGradesServiceModel(
+            new OfstedShortInspection(
+                DateTime.Parse("2025-04-03"),
+                "School remains Outstanding"),
+            new OfstedFullInspectionSummary(
+                DateTime.Parse("2023-04-03"),
+                OfstedRatingScore.Outstanding),
+            new OfstedFullInspectionSummary(
+                DateTime.Parse("2011-04-03"),
+                OfstedRatingScore.Good));
+
+        MockSchoolService.GetOfstedHeadlineGrades(SchoolUrn).Returns(expectedGrades);
+
+        await Sut.OnGetAsync();
+
+        Sut.HeadlineGrades.Should().Be(expectedGrades);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
@@ -73,6 +73,12 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
                 l.LinkDisplayText.Should().Be("Contacts");
                 l.AspPage.Should().Be("/Schools/Contacts/InSchool");
                 l.TestId.Should().Be("contacts-nav");
+            },
+            l =>
+            {
+                l.LinkDisplayText.Should().Be("Ofsted");
+                l.AspPage.Should().Be("/Schools/Ofsted/SingleHeadlineGrades");
+                l.TestId.Should().Be("ofsted-nav");
             }
         );
     }
@@ -98,6 +104,12 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
                 l.LinkDisplayText.Should().Be("Contacts");
                 l.AspPage.Should().Be("/Schools/Contacts/InDfe");
                 l.TestId.Should().Be("contacts-nav");
+            },
+            l =>
+            {
+                l.LinkDisplayText.Should().Be("Ofsted");
+                l.AspPage.Should().Be("/Schools/Ofsted/SingleHeadlineGrades");
+                l.TestId.Should().Be("ofsted-nav");
             }
         );
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/OfstedSchoolDataExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/OfstedSchoolDataExportServiceTests.cs
@@ -1,0 +1,196 @@
+using ClosedXML.Excel;
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Exceptions;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.Export;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices;
+
+public class OfstedSchoolDataExportServiceTests
+{
+    private const int SchoolUrn = 123456;
+    private const int AcademyUrn = 234567;
+
+    private readonly ISchoolService _mockSchoolService = Substitute.For<ISchoolService>();
+
+    private readonly ISchoolOverviewDetailsService _mockSchoolOverviewDetailsService =
+        Substitute.For<ISchoolOverviewDetailsService>();
+
+    private readonly OfstedSchoolDataExportService _sut;
+
+    private readonly SchoolSummaryServiceModel _schoolSummary;
+    private readonly SchoolSummaryServiceModel _academySummary;
+    private readonly SchoolOverviewServiceModel _schoolOverview;
+    private readonly SchoolOverviewServiceModel _academyOverview;
+    private readonly OfstedHeadlineGradesServiceModel _headlineGrades;
+
+    public OfstedSchoolDataExportServiceTests()
+    {
+        _schoolSummary =
+            new SchoolSummaryServiceModel(SchoolUrn, "Test School", "Some School Type",
+                SchoolCategory.LaMaintainedSchool);
+        _academySummary =
+            new SchoolSummaryServiceModel(AcademyUrn, "Test Academy", "Some Academy Type", SchoolCategory.Academy);
+
+        _schoolOverview = new SchoolOverviewServiceModel("Test School", "1 Some Street", "East of England", "Essex",
+            "Primary", new AgeRange(3, 11), NurseryProvision.HasClasses);
+        _academyOverview = new SchoolOverviewServiceModel("Test Academy", "2 Another Place", "South West",
+                "Devon and Cornwall", "Secondary", new AgeRange(11, 18), NurseryProvision.NoClasses)
+            { DateJoinedTrust = DateOnly.Parse("2014-09-01") };
+
+        _headlineGrades = new OfstedHeadlineGradesServiceModel(
+            new OfstedShortInspection(DateTime.Parse("2025-07-01"), "School remains Good"),
+            new OfstedFullInspectionSummary(DateTime.Parse("2020-07-01"), OfstedRatingScore.Good),
+            new OfstedFullInspectionSummary(DateTime.Parse("2010-07-01"), OfstedRatingScore.RequiresImprovement));
+
+        _mockSchoolService.GetSchoolSummaryAsync(SchoolUrn).Returns(_schoolSummary);
+        _mockSchoolService.GetSchoolSummaryAsync(AcademyUrn).Returns(_academySummary);
+
+        _mockSchoolOverviewDetailsService.GetSchoolOverviewDetailsAsync(SchoolUrn, SchoolCategory.LaMaintainedSchool)!
+            .Returns(_schoolOverview);
+        _mockSchoolOverviewDetailsService.GetSchoolOverviewDetailsAsync(AcademyUrn, SchoolCategory.Academy)!.Returns(
+            _academyOverview);
+
+        _mockSchoolService.GetOfstedHeadlineGrades(SchoolUrn)!.Returns(_headlineGrades);
+        _mockSchoolService.GetOfstedHeadlineGrades(AcademyUrn)!.Returns(_headlineGrades);
+
+        _sut = new OfstedSchoolDataExportService(_mockSchoolService, _mockSchoolOverviewDetailsService);
+    }
+
+    [Fact]
+    public async Task BuildAsync_should_generate_correct_headers()
+    {
+        var result = await GetWorksheetAsync(123456);
+
+        result.AssertSpreadsheetMatches(3, ["Inspection type", "Date of inspection", "Grade"]);
+    }
+
+    [Fact]
+    public async Task BuildAsync_when_school_is_not_found_then_throw_DataIntegrityException()
+    {
+        var unknownUrn = 999111;
+
+        var result = async () => { await _sut.BuildAsync(unknownUrn); };
+
+        await result.Should().ThrowAsync<DataIntegrityException>()
+            .WithMessage("School summary not found for urn: 999111");
+    }
+
+    [Fact]
+    public async Task BuildAsync_when_school_is_la_maintained_then_school_preamble_is_correct()
+    {
+        var result = await GetWorksheetAsync(SchoolUrn);
+
+        result.CellValue(1, 1).Should().Be(_schoolOverview.Name);
+        result.CellValue(2, 1).Should().Be("Not part of a trust");
+    }
+
+    [Fact]
+    public async Task BuildAsync_when_school_is_academy_then_school_preamble_is_correct()
+    {
+        var result = await GetWorksheetAsync(AcademyUrn);
+
+        result.CellValue(1, 1).Should().Be(_academyOverview.Name);
+        result.CellValue(2, 1).Should().Be("Joined trust on 01/09/2014");
+    }
+
+    [Fact]
+    public async Task BuildAsync_includes_expected_data()
+    {
+        var result = await GetWorksheetAsync(SchoolUrn);
+
+        AssertResultContainsExpectedRow(result, 4, "Recent short inspection",
+            _headlineGrades.ShortInspection.InspectionDate, _headlineGrades.ShortInspection.InspectionOutcome);
+
+        AssertResultContainsExpectedRow(result, 5, "Current inspection",
+            _headlineGrades.CurrentInspection.InspectionDate, "Good");
+        AssertResultContainsExpectedRow(result, 6, "Previous inspection",
+            _headlineGrades.PreviousInspection.InspectionDate, "Requires improvement");
+    }
+
+    [Fact]
+    public async Task BuildAsync_when_no_recent_short_inspection_then_includes_expected_data()
+    {
+        _mockSchoolService.GetOfstedHeadlineGrades(SchoolUrn)!.Returns(_headlineGrades with
+        {
+            ShortInspection = OfstedShortInspection.Unknown
+        });
+
+        var result = await GetWorksheetAsync(SchoolUrn);
+
+        AssertResultContainsExpectedRow(result, 4, "Current inspection",
+            _headlineGrades.CurrentInspection.InspectionDate, "Good");
+        AssertResultContainsExpectedRow(result, 5, "Previous inspection",
+            _headlineGrades.PreviousInspection.InspectionDate, "Requires improvement");
+    }
+
+    [Fact]
+    public async Task BuildAsync_when_inspection_dates_are_missing_then_includes_expected_data()
+    {
+        _mockSchoolService.GetOfstedHeadlineGrades(SchoolUrn)!.Returns(
+            _headlineGrades with
+            {
+                CurrentInspection = _headlineGrades.CurrentInspection with { InspectionDate = null },
+                PreviousInspection = _headlineGrades.PreviousInspection with { InspectionDate = null }
+            }
+        );
+
+        var result = await GetWorksheetAsync(SchoolUrn);
+
+        AssertResultContainsExpectedRow(result, 4, "Current inspection", null, "Good");
+        AssertResultContainsExpectedRow(result, 5, "Previous inspection", null, "Requires improvement");
+    }
+
+    [Fact]
+    public async Task BuildAsync_when_short_inspection_grade_is_missing_then_includes_expected_data()
+    {
+        _mockSchoolService.GetOfstedHeadlineGrades(SchoolUrn)!.Returns(
+            _headlineGrades with
+            {
+                ShortInspection = _headlineGrades.ShortInspection with { InspectionOutcome = null }
+            }
+        );
+
+        var result = await GetWorksheetAsync(SchoolUrn);
+
+        AssertResultContainsExpectedRow(result, 4, "Recent short inspection",
+            _headlineGrades.ShortInspection.InspectionDate, null);
+
+        AssertResultContainsExpectedRow(result, 5, "Current inspection",
+            _headlineGrades.CurrentInspection.InspectionDate, "Good");
+        AssertResultContainsExpectedRow(result, 6, "Previous inspection",
+            _headlineGrades.PreviousInspection.InspectionDate, "Requires improvement");
+    }
+
+    private async Task<IXLWorksheet> GetWorksheetAsync(int urn)
+    {
+        var bytes = await _sut.BuildAsync(urn);
+        var workbook = new XLWorkbook(new MemoryStream(bytes));
+        var worksheet = workbook.Worksheet("Ofsted");
+
+        worksheet.Should().NotBeNull();
+
+        return worksheet;
+    }
+
+    private static void AssertResultContainsExpectedRow(IXLWorksheet result, int row, string expectedInspectionType,
+        DateTime? expectedInspectionDate, string? expectedGrade)
+    {
+        result.CellValue(row, ExportColumns.OfstedSchoolColumns.InspectionType).Should().Be(expectedInspectionType);
+
+        if (expectedInspectionDate is null)
+        {
+            result.CellValue(row, ExportColumns.OfstedSchoolColumns.DateOfInspection).Should().Be(string.Empty);
+        }
+        else
+        {
+            result.Cell(row, ExportColumns.OfstedSchoolColumns.DateOfInspection).DataType.Should()
+                .Be(XLDataType.DateTime);
+            result.Cell(row, ExportColumns.OfstedSchoolColumns.DateOfInspection).GetValue<DateTime>().Should()
+                .Be(expectedInspectionDate);
+        }
+
+        result.CellValue(row, ExportColumns.OfstedSchoolColumns.Grade).Should().Be(expectedGrade ?? string.Empty);
+    }
+}


### PR DESCRIPTION
This PR adds the 'Single headline grades' page to a school. It allows a user to get an overview of the current and previous Ofsted inspections, as well as the results of any recent short inspections.

> [!Note]
> See [User Story 205477](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205477): Build: Ungraded inspections data for a school/academy

## Changes

- The `OfstedSchoolDataExportService` has been introduced, which allows users to download an Excel file containing the Ofsted report data for a school. Currently, this just matches the data on the 'single headline grades' page, but will be expanded in the future.
- The `OtherServicesLinkBuilder` now provides a `OfstedReportLinkForSchool` method that takes in a URN and returns a URL of the format `https://reports.ofsted.gov.uk/inspection-reports/find-inspection-report/provider/ELS/{urn}`.
- A base `OfstedAreaModel` has been introduced that contains common view logic for all pages in the Ofsted area for a school.
- A `SingleHeadlineGrades.cshtml` view and `SingleHeadlineGradesModel` page model have been introduced to present the Ofsted report summary information to the user.
- The `SchoolNavMenu` utility service has been updated to provide links to the 'single headline grades' page so that it is accessible from the rest of the application.

## Screenshots of UI changes

### Before

### After

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
