### PR TITLE
[229233] Single headline grade fixes/improvements

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Extensions/DateTimeExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/DateTimeExtensions.cs
@@ -15,6 +15,17 @@ public static class DateTimeExtensions
         return replacementText;
     }
 
+    public static string ShowFullDateStringOrReplaceWithText(this DateTime? date,
+        string replacementText = ViewConstants.NoDataText)
+    {
+        if (date.HasValue)
+        {
+            return date.Value.ToString(StringFormatConstants.DisplayFullDateFormat);
+        }
+
+        return replacementText;
+    }
+
     public static string ToDataSortValue(this DateTime date)
     {
         return date.ToString(StringFormatConstants.SortableDateFormat);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
@@ -15,7 +15,8 @@
         @if (Model.DateJoinedTrust is not null)
         {
             <p class="govuk-body" data-testid="academy-joined-trust-text">This academy joined the trust on
-                <strong>@Model.DateJoinedTrust.ShowDateStringOrReplaceWithText()</strong>.</p>
+                <strong>@Model.DateJoinedTrust.ShowFullDateStringOrReplaceWithText()</strong>.
+            </p>
         }
 
         <details class="govuk-details" data-testid="why-single-headline-not-available-details">
@@ -43,9 +44,8 @@
             </summary>
 
             <div class="govuk-details__text">
-                <p class="govuk-body">A grade and date of a short inspection may not be available, when a full
-                    inspection has followed it.</p>
-                <p class="govuk-body">The data can be found in the school's Ofsted inspection reports.</p>
+                <p class="govuk-body">If a school has a short Ofsted inspection followed by a full one, data about the short inspection may not appear on this page.</p>
+                <p class="govuk-body">Ofsted's inspection report will contain this data.</p>
             </div>
         </details>
 
@@ -67,20 +67,20 @@
             {
                 <tr class="govuk-table__row" data-testid="recent-short-inspection-row">
                     <th scope="row" class="govuk-table__cell">Recent short inspection</th>
-                    <td class="govuk-table__cell" data-testid="recent-short-inspection-date">@Model.HeadlineGrades.ShortInspection.InspectionDate.ShowDateStringOrReplaceWithText("Not available")</td>
+                        <td class="govuk-table__cell" data-testid="recent-short-inspection-date">@Model.HeadlineGrades.ShortInspection.InspectionDate.ShowFullDateStringOrReplaceWithText("Not available")</td>
                     <td class="govuk-table__cell" data-testid="recent-short-inspection-grade">@Model.HeadlineGrades.ShortInspection.InspectionOutcome</td>
                 </tr>
             }
 
             <tr class="govuk-table__row" data-testid="current-full-inspection-row">
                 <th scope="row" class="govuk-table__cell">Current full inspection</th>
-                <td class="govuk-table__cell" data-testid="current-full-inspection-date">@Model.HeadlineGrades.CurrentInspection.InspectionDate.ShowDateStringOrReplaceWithText("Not available")</td>
+                    <td class="govuk-table__cell" data-testid="current-full-inspection-date">@Model.HeadlineGrades.CurrentInspection.InspectionDate.ShowFullDateStringOrReplaceWithText("Not available")</td>
                 <td class="govuk-table__cell" data-testid="current-full-inspection-grade">@Model.HeadlineGrades.CurrentInspection.InspectionOutcome.ToDisplayString(true)</td>
             </tr>
 
             <tr class="govuk-table__row" data-testid="previous-full-inspection-row">
                 <th scope="row" class="govuk-table__cell">Previous full inspection</th>
-                <td class="govuk-table__cell" data-testid="previous-full-inspection-date">@Model.HeadlineGrades.PreviousInspection.InspectionDate.ShowDateStringOrReplaceWithText("Not available")</td>
+                    <td class="govuk-table__cell" data-testid="previous-full-inspection-date">@Model.HeadlineGrades.PreviousInspection.InspectionDate.ShowFullDateStringOrReplaceWithText("Not available")</td>
                 <td class="govuk-table__cell" data-testid="previous-full-inspection-grade">@Model.HeadlineGrades.PreviousInspection.InspectionOutcome.ToDisplayString(false)</td>
             </tr>
             </tbody>
@@ -92,9 +92,16 @@
 
         <hr class="govuk-section-break govuk-section-break--m">
 
-        <a asp-page-handler="Export" asp-route-urn="@Model.Urn" draggable="false" class="govuk-button govuk-button--secondary"
-           data-module="govuk-button" data-govuk-button-init="" data-testid="download-all-ofsted-data-button">
-            Download all Ofsted data
-        </a>
+        
+        <section class="govuk-!-margin-top-2 govuk-!-margin-bottom-2 export-container">
+            <input type="hidden" name="urn" value="@Model.Urn" />
+            <a asp-page-handler="Export" asp-route-urn="@Model.Urn"
+               class="govuk-button govuk-button--secondary export-button--with-icon" data-testid="download-all-ofsted-data-button">
+                <svg class="export-button__icon" width="20" height="20" viewBox="0 0 29 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                    <path d="M24.968 17.5V22.1667C24.968 22.7855 24.7222 23.379 24.2846 23.8166C23.847 24.2542 23.2535 24.5 22.6347 24.5H6.30135C5.68251 24.5 5.08902 24.2542 4.65143 23.8166C4.21385 23.379 3.96802 22.7855 3.96802 22.1667V17.5M8.63468 11.6667L14.468 17.5M14.468 17.5L20.3014 11.6667M14.468 17.5V3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Download all Ofsted data
+            </a>
+        </section>
     </div>
 </div>

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
@@ -135,6 +135,14 @@ class CommonPage {
         // Tech debt - We are allowing Sep and Sept due to different cultures set on remote vs local builds
         expect(text).to.match(/^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec) \d{4}$|^No data$/);
     };
+
+    public readonly checkValueIsValidFullDate = (element: JQuery<HTMLElement>) => {
+        const text = element.text().trim();
+
+        // Resolves to a date ({2 digits} {month} {4 digits}) or "No data" string
+        // Tech debt - We are allowing Sep and Sept due to different cultures set on remote vs local builds
+        expect(text).to.match(/^\d{1,2} (January|February|March|April|May|June|July|August|September|October|November|December) \d{4}$|^No data$/);
+    };
 }
 
 const commonPage = new CommonPage();

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolOfstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolOfstedPage.ts
@@ -158,17 +158,17 @@ class SchoolOfstedPage {
 
     // Date validation methods
     public checkCurrentFullInspectionDateValid(): this {
-        this.elements.singleHeadlineGrades.currentFullInspectionDate().each(commonPage.checkValueIsValidDate);
+        this.elements.singleHeadlineGrades.currentFullInspectionDate().each(commonPage.checkValueIsValidFullDate);
         return this;
     }
 
     public checkPreviousFullInspectionDateValid(): this {
-        this.elements.singleHeadlineGrades.previousFullInspectionDate().each(commonPage.checkValueIsValidDate);
+        this.elements.singleHeadlineGrades.previousFullInspectionDate().each(commonPage.checkValueIsValidFullDate);
         return this;
     }
 
     public checkRecentShortInspectionDateValid(): this {
-        this.elements.singleHeadlineGrades.recentShortInspectionDate().each(commonPage.checkValueIsValidDate);
+        this.elements.singleHeadlineGrades.recentShortInspectionDate().each(commonPage.checkValueIsValidFullDate);
         return this;
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/DateTimeExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/DateTimeExtensionsTests.cs
@@ -21,6 +21,22 @@ public class DateTimeExtensionsTests
         result.Should().Be("No data");
     }
 
+    [Fact]
+    public void ShowFullDateStringOrReplaceWithText_ReturnsFormattedDate_WhenNotNull()
+    {
+        DateTime? testTime = DateTime.Today;
+        var result = testTime.ShowFullDateStringOrReplaceWithText();
+        result.Should().BeEquivalentTo(DateTime.Today.ToString(StringFormatConstants.DisplayFullDateFormat));
+    }
+
+    [Fact]
+    public void ShowFullDateStringOrReplaceWithText_returns_NoData_WhenNull()
+    {
+        DateTime? testTime = null;
+        var result = testTime.ShowFullDateStringOrReplaceWithText();
+        result.Should().Be("No data");
+    }
+
     [Theory]
     [InlineData(2024, 12, 31, "20241231")]
     [InlineData(2024, 12, 03, "20241203")]


### PR DESCRIPTION
This pull request addresses some changes for the UI

- For the school/academy pages user the full month string for dates on the single headline grade ofstead page.
- Change the export button to use the same styling as elsewhere.
-  Wording changes for why the short inspection data may not be available

[Bug 229233](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/229233): [BUG] Schools - Ofsted - Single headline grade fixes/improvements


## Screenshots of UI changes

### Before
<img width="805" height="629" alt="image" src="https://github.com/user-attachments/assets/f6e48882-f30b-40ca-a293-46b6586317df" />

### After
<img width="821" height="631" alt="image" src="https://github.com/user-attachments/assets/ffedb19f-e2a2-40c1-824b-3857832d9aef" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] Testing complete - all manual and automated tests pass
