### PR TITLE
Add 'current ratings' page to Ofsted area of a school or academy

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/CurrentRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/CurrentRatings.cshtml
@@ -1,0 +1,119 @@
+@page
+@using System.ComponentModel
+@using DfE.FindInformationAcademiesTrusts.Data.Enums
+@using DfE.FindInformationAcademiesTrusts.Extensions
+@model CurrentRatingsModel
+
+@{
+    Layout = "_SchoolLayout";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m">@Model.PageMetadata.SubPageName</h3>
+        
+        <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                    Quality of education
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.OfstedRating.QualityOfEducation.ToDisplayString(false)
+                </dd>
+            </div>
+            
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                    Behaviour and attitudes
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.OfstedRating.BehaviourAndAttitudes.ToDisplayString(false)
+                </dd>
+            </div>
+            
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                    Personal development
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.OfstedRating.PersonalDevelopment.ToDisplayString(false)
+                </dd>
+            </div>
+            
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                    Leadership and management
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.OfstedRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(false)
+                </dd>
+            </div>
+            
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                    Early years provision
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.OfstedRating.EarlyYearsProvision.ToDisplayString(false)
+                </dd>
+            </div>
+            
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                    Sixth form provision
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.OfstedRating.SixthFormProvision.ToDisplayString(false)
+                </dd>
+            </div>
+            
+            @if (Model.InspectionBeforeOrAfterJoiningTrust != BeforeOrAfterJoining.NotApplicable)
+            {
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                        Before or after joining the trust
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @switch (Model.InspectionBeforeOrAfterJoiningTrust)
+                        {
+                            case BeforeOrAfterJoining.Before:
+                                <strong class="govuk-tag govuk-tag--grey">
+                                    Before joining
+                                </strong>
+                                break;
+                            case BeforeOrAfterJoining.After:
+                                <strong class="govuk-tag">
+                                    After joining
+                                </strong>
+                                break;
+                            case BeforeOrAfterJoining.NotYetInspected:
+                                <strong class="govuk-tag govuk-tag--grey">
+                                    Not yet inspected
+                                </strong>
+                                break;
+                            default:
+                                throw new InvalidEnumArgumentException($"Unknown value of BeforeOrAfterJoining: {Model.InspectionBeforeOrAfterJoiningTrust}");
+                        }
+                    </dd>
+                </div>
+            }
+        </dl>
+        
+        <hr class="govuk-section-break govuk-section-break--m">
+
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted</a>.</p>
+
+        <hr class="govuk-section-break govuk-section-break--m">
+
+        <section class="govuk-!-margin-top-2 govuk-!-margin-bottom-2 export-container">
+            <input type="hidden" name="urn" value="@Model.Urn" />
+            <a asp-page-handler="Export" asp-route-urn="@Model.Urn"
+               class="govuk-button govuk-button--secondary export-button--with-icon" data-testid="download-all-ofsted-data-button">
+                <svg class="export-button__icon" width="20" height="20" viewBox="0 0 29 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                    <path d="M24.968 17.5V22.1667C24.968 22.7855 24.7222 23.379 24.2846 23.8166C23.847 24.2542 23.2535 24.5 22.6347 24.5H6.30135C5.68251 24.5 5.08902 24.2542 4.65143 23.8166C4.21385 23.379 3.96802 22.7855 3.96802 22.1667V17.5M8.63468 11.6667L14.468 17.5M14.468 17.5L20.3014 11.6667M14.468 17.5V3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Download all Ofsted data
+            </a>
+        </section>
+    </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/CurrentRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/CurrentRatings.cshtml.cs
@@ -1,0 +1,34 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Export;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
+
+public class CurrentRatingsModel(ISchoolService schoolService, ISchoolOverviewDetailsService schoolOverviewDetailsService, ITrustService trustService, IDataSourceService dataSourceService, IOfstedSchoolDataExportService ofstedSchoolDataExportService, IDateTimeProvider dateTimeProvider, IOtherServicesLinkBuilder otherServicesLinkBuilder, ISchoolNavMenu schoolNavMenu) : OfstedAreaModel(schoolService, schoolOverviewDetailsService, trustService, dataSourceService, ofstedSchoolDataExportService, dateTimeProvider, otherServicesLinkBuilder, schoolNavMenu)
+{
+    public const string SubPageName = "Current ratings";
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
+
+    public OfstedRating OfstedRating { get; set; } = null!;
+    public BeforeOrAfterJoining InspectionBeforeOrAfterJoiningTrust { get; set; }
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+        
+        if (pageResult is NotFoundResult) return pageResult;
+        
+        var ofstedRatings = await SchoolService.GetSchoolOfstedRatingsAsync(Urn);
+
+        OfstedRating = ofstedRatings.CurrentOfstedRating;
+
+        InspectionBeforeOrAfterJoiningTrust = ofstedRatings.WhenDidCurrentInspectionHappen;
+        
+        return pageResult;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/OfstedAreaModel.cs
@@ -57,6 +57,10 @@ public class OfstedAreaModel(
                 new DataSourceListEntry(dataSources, "Single headline grades were"),
                 new DataSourceListEntry(dataSources, "All inspection dates were")
             ]),
+            new DataSourcePageListEntry(CurrentRatingsModel.SubPageName, [
+                new DataSourceListEntry(misDataSource, "Current Ofsted rating"),
+                new DataSourceListEntry(misDataSource, "Date of current inspection")
+            ]),
             new DataSourcePageListEntry(PreviousRatingsModel.SubPageName, [
                 new DataSourceListEntry(misDataSource, "Previous Ofsted rating"),
                 new DataSourceListEntry(misDataSource, "Date of previous inspection")

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
@@ -139,6 +139,8 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
         [
             GetSubNavLinkTo<SingleHeadlineGradesModel>(OfstedAreaModel.PageName, SingleHeadlineGradesModel.SubPageName,
                 "/Schools/Ofsted/SingleHeadlineGrades", activePage, "ofsted-single-headline-grades-subnav"),
+            GetSubNavLinkTo<CurrentRatingsModel>(OfstedAreaModel.PageName, CurrentRatingsModel.SubPageName,
+                "/Schools/Ofsted/CurrentRatings", activePage, "ofsted-current-ratings-subnav"),
             GetSubNavLinkTo<PreviousRatingsModel>(OfstedAreaModel.PageName, PreviousRatingsModel.SubPageName,
                 "/Schools/Ofsted/PreviousRatings", activePage, "ofsted-previous-ratings-subnav")
         ];

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/BaseOfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/BaseOfstedAreaModelTests.cs
@@ -147,6 +147,10 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseSchoolPageTests<T> where
                 new DataSourceListEntry(expectedDataSources, "Single headline grades were"),
                 new DataSourceListEntry(expectedDataSources, "All inspection dates were")
             ]),
+            new DataSourcePageListEntry("Current ratings", [
+                new DataSourceListEntry(Mocks.MockDataSourceService.Mis, "Current Ofsted rating"),
+                new DataSourceListEntry(Mocks.MockDataSourceService.Mis, "Date of current inspection"),
+            ]),
             new DataSourcePageListEntry("Previous ratings", [
                 new DataSourceListEntry(Mocks.MockDataSourceService.Mis, "Previous Ofsted rating"),
                 new DataSourceListEntry(Mocks.MockDataSourceService.Mis, "Date of previous inspection")

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/CurrentRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Ofsted/CurrentRatingsModelTests.cs
@@ -1,0 +1,163 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
+using DfE.FindInformationAcademiesTrusts.Services.Academy;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Ofsted;
+
+public class CurrentRatingsModelTests : BaseOfstedAreaModelTests<CurrentRatingsModel>
+{
+    private readonly SchoolOfstedServiceModel _dummySchoolOfstedServiceModel = new SchoolOfstedServiceModel(
+        SchoolUrn.ToString(),
+        null,
+        null,
+        OfstedShortInspection.Unknown,
+        OfstedRating.Unknown,
+        OfstedRating.Unknown
+    );
+
+    private readonly TrustSummaryServiceModel _dummyTrustSummaryServiceModel = new TrustSummaryServiceModel(
+        "1234",
+        "Some Trust",
+        "Some Trust Type",
+        23
+    );
+    
+    public CurrentRatingsModelTests()
+    {
+        Sut = new CurrentRatingsModel(
+                MockSchoolService,
+                MockSchoolOverviewDetailsService,
+                MockTrustService,
+                MockDataSourceService,
+                MockOfstedSchoolDataExportService,
+                MockDateTimeProvider,
+                MockOtherServicesLinkBuilder,
+                MockSchoolNavMenu)
+            { Urn = SchoolUrn };
+
+        MockSchoolService.GetSchoolOfstedRatingsAsync(Arg.Any<int>()).Returns(_dummySchoolOfstedServiceModel);
+        MockTrustService.GetTrustSummaryAsync(AcademyUrn).Returns(_dummyTrustSummaryServiceModel);
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_PageMetadata_SubPageName()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.SubPageName.Should().Be("Current ratings");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_correct_OfstedRating_data()
+    {
+        var expectedRating = new OfstedRating(
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            CategoriesOfConcern.NoConcerns,
+            SafeguardingScore.Yes,
+            new DateTime(2025, 1, 1)
+        );
+
+        MockSchoolService
+            .GetSchoolOfstedRatingsAsync(SchoolUrn)
+            .Returns(_dummySchoolOfstedServiceModel with { CurrentOfstedRating = expectedRating });
+
+        await Sut.OnGetAsync();
+
+        Sut.OfstedRating.Should().Be(expectedRating);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_InspectionBeforeOrAfterJoiningTrust_to_not_applicable_when_school_is_la()
+    {
+        var expectedRating = new OfstedRating(
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            CategoriesOfConcern.NoConcerns,
+            SafeguardingScore.Yes,
+            new DateTime(2025, 1, 1)
+        );
+
+        MockSchoolService
+            .GetSchoolOfstedRatingsAsync(SchoolUrn)
+            .Returns(_dummySchoolOfstedServiceModel with { CurrentOfstedRating = expectedRating });
+
+        await Sut.OnGetAsync();
+
+        Sut.InspectionBeforeOrAfterJoiningTrust.Should().Be(BeforeOrAfterJoining.NotApplicable);
+    }
+    
+    [Fact]
+    public async Task OnGetAsync_should_set_InspectionBeforeOrAfterJoiningTrust_to_after_when_school_is_academy_and_previous_inspection_date_is_after_date_joined_trust()
+    {
+        Sut.Urn = AcademyUrn;
+        
+        var expectedRating = new OfstedRating(
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            CategoriesOfConcern.NoConcerns,
+            SafeguardingScore.Yes,
+            new DateTime(2025, 1, 1)
+        );
+
+        MockSchoolService
+            .GetSchoolOfstedRatingsAsync(AcademyUrn)
+            .Returns(_dummySchoolOfstedServiceModel with
+            {
+                DateAcademyJoinedTrust = new DateTime(2024, 1, 1),
+                CurrentOfstedRating = expectedRating
+            });
+
+        await Sut.OnGetAsync();
+
+        Sut.InspectionBeforeOrAfterJoiningTrust.Should().Be(BeforeOrAfterJoining.After);
+    }
+    
+    [Fact]
+    public async Task OnGetAsync_should_set_InspectionBeforeJoiningTrust_to_before_when_school_is_academy_and_previous_inspection_date_is_before_date_joined_trust()
+    {
+        Sut.Urn = AcademyUrn;
+        
+        var expectedRating = new OfstedRating(
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            OfstedRatingScore.Good,
+            CategoriesOfConcern.NoConcerns,
+            SafeguardingScore.Yes,
+            new DateTime(2025, 1, 1)
+        );
+
+        MockSchoolService
+            .GetSchoolOfstedRatingsAsync(AcademyUrn)
+            .Returns(_dummySchoolOfstedServiceModel with
+            {
+                DateAcademyJoinedTrust = new DateTime(2026, 1, 1),
+                CurrentOfstedRating = expectedRating
+            });
+
+        await Sut.OnGetAsync();
+
+        Sut.InspectionBeforeOrAfterJoiningTrust.Should().Be(BeforeOrAfterJoining.Before);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
@@ -175,6 +175,7 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
             nameof(CurrentModel) => "/Schools/Governance/Current",
             nameof(HistoricModel) => "/Schools/Governance/Current",
             nameof(SingleHeadlineGradesModel) => "/Schools/Ofsted/SingleHeadlineGrades",
+            nameof(CurrentRatingsModel) => "/Schools/Ofsted/SingleHeadlineGrades",
             nameof(PreviousRatingsModel) => "/Schools/Ofsted/SingleHeadlineGrades",
             _ => throw new ArgumentException("Couldn't get expected service nav asp link for given page type",
                 nameof(pageType))

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
@@ -54,6 +54,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
             nameof(CurrentModel) => "Governance",
             nameof(HistoricModel) => "Governance",
             nameof(SingleHeadlineGradesModel) => "Ofsted",
+            nameof(CurrentRatingsModel) => "Ofsted",
             nameof(PreviousRatingsModel) => "Ofsted",
             _ => throw new ArgumentException("Couldn't get expected name for given page type", nameof(pageType))
         };
@@ -102,6 +103,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
             nameof(CurrentModel) => "/Schools/Governance/Current",
             nameof(HistoricModel) => "/Schools/Governance/Historic",
             nameof(SingleHeadlineGradesModel) => "/Schools/Ofsted/SingleHeadlineGrades",
+            nameof(CurrentRatingsModel) => "/Schools/Ofsted/CurrentRatings",
             nameof(PreviousRatingsModel) => "/Schools/Ofsted/PreviousRatings",
             _ => throw new ArgumentException("Couldn't get expected sub page nav asp link for given page type",
                 nameof(pageType))

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
@@ -34,6 +34,7 @@ public abstract class SchoolNavMenuTestsBase
         typeof(HistoricModel),
         //Ofsted
         typeof(SingleHeadlineGradesModel),
+        typeof(CurrentRatingsModel),
         typeof(PreviousRatingsModel)
     ];
 
@@ -51,6 +52,7 @@ public abstract class SchoolNavMenuTestsBase
         typeof(HistoricModel),
         //Ofsted
         typeof(SingleHeadlineGradesModel),
+        typeof(CurrentRatingsModel),
         typeof(PreviousRatingsModel)
     ];
 


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 205653](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205653): Build: Current ratings data for an academy/school. Other branches for this feature should be merged into this one.

This PR introduces a new page to the Ofsted section for a school or academy that displays the current Ofsted rating for that school.

## Changes
- The `CurrentRatings.cshtml` Razor page and `CurrentRatingsModel` page model have been introduced to implement the new page.
- The `SchoolNavMenu` utility service has been updated to provide links to the new page.
- The `OfstedAreaModel` page model class has been updated to include new data sources specific to the new page.

## Screenshots of UI changes

Example of the new page:
<img width="1418" height="2176" alt="" src="https://github.com/user-attachments/assets/aaddd36a-b54d-42f0-89b7-de25deb2e80d" />

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
