### PR TITLE
Add links to academies in trust pages

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
@@ -28,7 +28,7 @@
       {
         <tr class="govuk-table__row" data-testid="academy-row">
           <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
-            @academy.EstablishmentName
+            <partial name="Trusts/_AcademyLink" model="@new AcademyLinkModel(academy.EstablishmentName, academy.Urn)" />
           </td>
           <td class="govuk-body govuk-table__cell" data-testid="urn">@academy.Urn</td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@academy.DateAcademyJoinedTrust.ToString(StringFormatConstants.SortableDateFormat)" data-testid="academy-date-joined">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml
@@ -22,7 +22,7 @@
             {
                 <tr class="govuk-table__row" data-testid="academy-row">
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
-                        @academy.EstablishmentName
+                        <partial name="Trusts/_AcademyLink" model="@new AcademyLinkModel(academy.EstablishmentName, academy.Urn)" />
                     </td>
                     <td class="govuk-body govuk-table__cell" data-testid="urn">@academy.Urn</td>
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.PercentageFreeSchoolMeals" data-testid="pupils-eligible">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml
@@ -27,7 +27,7 @@
     {
       <tr class="govuk-table__row" data-testid="academy-row">
         <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
-          @academy.EstablishmentName
+          <partial name="Trusts/_AcademyLink" model="@new AcademyLinkModel(academy.EstablishmentName, academy.Urn)" />
         </td>
         <td class="govuk-body govuk-table__cell" data-testid="urn">@academy.Urn</td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@PupilNumbersModel.PhaseAndAgeRangeSortValue(academy)"

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
@@ -47,7 +47,7 @@
                 <tr class="govuk-table__row" data-testid="academy-row">
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName"
                         data-testid="free-schools-board-school-name">
-                        @academy.EstablishmentName.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)
+                        <partial name="Trusts/_AcademyLink" model="@new AcademyLinkModel(academy.EstablishmentName.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText), academy.Urn)" />
                     </td>
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.Urn"
                         data-testid="free-schools-URN">@academy.Urn.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)</td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml
@@ -48,7 +48,7 @@
                 <tr class="govuk-table__row" data-testid="academy-row">
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName"
                         data-testid="post-advisory-board-school-name">
-                        @academy.EstablishmentName.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)
+                        <partial name="Trusts/_AcademyLink" model="@new AcademyLinkModel(academy.EstablishmentName.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText), academy.Urn)" />
                     </td>
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.Urn"
                         data-testid="post-advisory-board-URN">@academy.Urn.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)</td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml
@@ -47,7 +47,9 @@
             {
                 <tr class="govuk-table__row" data-testid="academy-row">
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName"
-                        data-testid="pre-advisory-board-school-name">@academy.EstablishmentName.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)</td>
+                        data-testid="pre-advisory-board-school-name">
+                        <partial name="Trusts/_AcademyLink" model="@new AcademyLinkModel(academy.EstablishmentName.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText), academy.Urn)" />
+                    </td>
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.Urn"
                         data-testid="pre-advisory-board-URN">@academy.Urn.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)</td>
                     <td class="govuk-body govuk-table__cell" data-sort-value="@academy.AgeRange.ToDataSortValue()"

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
@@ -80,7 +80,7 @@
     {
       <tr class="govuk-table__row" data-testid="academy-row">
         <td class="govuk-table__cell govuk-body" data-sort-value="@academy.EstablishmentName" data-testid="ofsted-single-headline-grades-school-name">
-          @academy.EstablishmentName<br/>
+          <partial name="Trusts/_AcademyLink" model="@new AcademyLinkModel(academy.EstablishmentName, academy.Urn)" />
         </td>
         <td class="govuk-table__cell govuk-body" data-sort-value="@academy.DateAcademyJoinedTrust!.Value.ToString(StringFormatConstants.SortableDateFormat)" data-testid="ofsted-single-headline-grades-date-joined">
           @academy.DateAcademyJoinedTrust!.Value.ToString(StringFormatConstants.DisplayDateFormat)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
@@ -42,8 +42,8 @@
     </div>
   </details>
   <hr class="govuk-section-break govuk-section-break--m">
-  <table class="govuk-table" data-module="moj-sortable-table">
-    <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Single headline grades</caption>
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="ofsted-caption">
+    <caption id="ofsted-caption" class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Single headline grades</caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-body" aria-sort="ascending"

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_AcademyLink.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_AcademyLink.cshtml
@@ -1,0 +1,12 @@
+@model DfE.FindInformationAcademiesTrusts.Pages.Trusts.AcademyLinkModel
+
+@if (Model.Urn is not null)
+{
+    <a class="govuk-link" asp-page="/Schools/Overview/Details" asp-route-urn="@Model.Urn">
+        @Model.EstablishmentName
+    </a>
+}
+else
+{
+    @Model.EstablishmentName
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_AcademyLink.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_AcademyLink.cshtml.cs
@@ -1,0 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+
+[ExcludeFromCodeCoverage(Justification = "Record with no behaviour and only used within Razor pages")]
+public record AcademyLinkModel(string? EstablishmentName, string? Urn);

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
@@ -89,6 +89,10 @@ describe("Testing the Ofsted page and its subpages ", () => {
                 .deleteDownloadedFile();
         });
 
+        it('checks that each academy name is a link to the academy details page with the correct URN', () => {
+            ofstedPage.checkSchoolNamesAreCorrectLinksOnSingleHeadlineGradesPage();
+        });
+
     });
 
     describe("Testing the Ofsted current ratings page ", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
@@ -58,6 +58,10 @@ describe("Testing the components of the Academies page", () => {
                 academiesInTrustPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);
             });
         });
+        
+        it('checks that each academy name is a link to the academy details page with the correct URN', () => {
+            academiesInTrustPage.checkSchoolNamesAreCorrectLinksOnDetailsPage(); 
+        });
     });
 
 
@@ -104,6 +108,10 @@ describe("Testing the components of the Academies page", () => {
             academiesInTrustPage
                 .checkCorrectPhaseTypePresent();
         });
+
+        it('checks that each academy name is a link to the academy details page with the correct URN', () => {
+            academiesInTrustPage.checkSchoolNamesAreCorrectLinksOnPupilNumbersPage();
+        });
     });
 
     describe("Free school meals", () => {
@@ -145,6 +153,9 @@ describe("Testing the components of the Academies page", () => {
                 .checkFreeSchoolMealsSorting();
         });
 
+        it('checks that each academy name is a link to the academy details page with the correct URN', () => {
+            academiesInTrustPage.checkSchoolNamesAreCorrectLinksOnFreeSchoolMealsPage();
+        });
     });
 
     describe("Testing a trust that has no academies within it to ensure the issue of a 500 page appearing does not happen", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/pipeline-academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/pipeline-academies.cy.ts
@@ -51,6 +51,9 @@ describe("Testing the Pipeline academies pages", () => {
                     .deleteDownloadedFile();
             });
 
+            it('checks that each academy name is a link to the academy details page with the correct URN', () => {
+                pipelineAcademiesPage.checkSchoolNamesAreCorrectLinksOnPreAdvisoryPage();
+            });
         });
     });
 
@@ -96,6 +99,10 @@ describe("Testing the Pipeline academies pages", () => {
             });
 
         });
+
+        it('checks that each academy name is a link to the academy details page with the correct URN', () => {
+            pipelineAcademiesPage.checkSchoolNamesAreCorrectLinksOnPostAdvisoryPage();
+        });
     });
 
     describe(`On the Free schools page`, () => {
@@ -139,6 +146,9 @@ describe("Testing the Pipeline academies pages", () => {
                     .checkFreeSchoolsCorrectProvisionalOpenDatePresent();
             });
 
+            it('checks that each academy name does not have a link as URNs are not available', () => {
+                pipelineAcademiesPage.checkSchoolNamesAreNotLinksOnFreeSchools();
+            });
         });
     });
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/tableUtility.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/tableUtility.ts
@@ -107,4 +107,24 @@ export class TableUtility {
             });
         });
     }
+
+    public static checkSchoolNamesAreCorrectLinksOnPage(
+        page: { tableRows(): Cypress.Chainable<JQuery<HTMLElement>> },
+        schoolNameTestId: string,
+        urnTestId?: string,
+    ) {
+        page.tableRows().each(element => {
+            const urnElement = urnTestId ? element.find(`[data-testid="${urnTestId}"]`) : null;
+            const schoolNameElement = element.find(`[data-testid="${schoolNameTestId}"]`);
+
+            expect(schoolNameElement.children().length).to.equal(1);
+            expect(schoolNameElement.children('a').length).to.equal(1);
+
+            if (urnElement !== null) {
+                expect(schoolNameElement.children('a').first().attr('href')).to.equal(`/schools/overview/details?urn=${urnElement.text().trim()}`);
+            } else {
+                expect(schoolNameElement.children('a').first().attr('href')).to.match(/^\/schools\/overview\/details\?urn=\d+$/);
+            }
+        });
+    }
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
@@ -110,6 +110,21 @@ class AcademiesInTrustPage {
             .and('contain', 'Get information about schools');
         return this;
     }
+    
+    public checkSchoolNamesAreCorrectLinksOnDetailsPage(): this {
+        TableUtility.checkSchoolNamesAreCorrectLinksOnPage(this.elements.detailsPage, "school-name", "urn");
+        return this;
+    }
+
+    public checkSchoolNamesAreCorrectLinksOnPupilNumbersPage(): this {
+        TableUtility.checkSchoolNamesAreCorrectLinksOnPage(this.elements.pupilNumbersPage, "school-name", "urn");
+        return this;
+    }
+
+    public checkSchoolNamesAreCorrectLinksOnFreeSchoolMealsPage(): this {
+        TableUtility.checkSchoolNamesAreCorrectLinksOnPage(this.elements.freeSchoolMeals, "school-name", "urn");
+        return this;
+    }
 
     public checkPupilNumbersHeadersPresent(): this {
         const { pupilNumbersPage } = this.elements;

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -8,6 +8,8 @@ class OfstedPage {
         downloadButton: () => cy.get('[data-testid="download-all-ofsted-data-button"]'),
         singleHeadlineGrades: {
             section: () => cy.get('[data-testid="ofsted-single-headline-grades-school-name-table"]'),
+            table: () => this.elements.singleHeadlineGrades.section().find('[aria-describedby="ofsted-caption"]'),
+            tableRows: () => this.elements.singleHeadlineGrades.table().find('tbody tr'),
             schoolName: () => this.elements.singleHeadlineGrades.section().find('[data-testid="ofsted-single-headline-grades-school-name"]'),
             schoolNameHeader: () => this.elements.singleHeadlineGrades.section().find('[data-testid="ofsted-single-headline-grades-school-name-header"]'),
             dateJoined: () => this.elements.singleHeadlineGrades.section().find('[data-testid="ofsted-single-headline-grades-date-joined"]'),
@@ -242,6 +244,11 @@ class OfstedPage {
 
     public checkWhySingleHeadlineNotAvailableDetailsIsOpen(): this {
         this.elements.singleHeadlineGrades.whySingleHeadlineNotAvailableDetails().should('have.attr', 'open');
+        return this;
+    }
+
+    public checkSchoolNamesAreCorrectLinksOnSingleHeadlineGradesPage(): this {
+        TableUtility.checkSchoolNamesAreCorrectLinksOnPage(this.elements.singleHeadlineGrades, 'ofsted-single-headline-grades-school-name');
         return this;
     }
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
@@ -8,6 +8,8 @@ class PipelineAcademies {
         downloadButton: () => cy.get('[data-testid="download-all-pipeline-data-button"]'),
         preAdvisory: {
             section: () => cy.get('[data-testid="pre-advisory-board-table"]'),
+            table: () => this.elements.preAdvisory.section().find('[aria-describedby="pre-advisory-caption"]'),
+            tableRows: () => this.elements.preAdvisory.table().find('tbody tr'),
             schoolName: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-school-name"]'),
             schoolNameHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-school-name-header"]'),
             urn: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-URN"]'),
@@ -23,6 +25,8 @@ class PipelineAcademies {
         },
         postAdvisory: {
             section: () => cy.get('[data-testid="post-advisory-board-table"]'),
+            table: () => this.elements.postAdvisory.section().find('[aria-describedby="post-advisory-caption"]'),
+            tableRows: () => this.elements.postAdvisory.table().find('tbody tr'),
             schoolName: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-school-name"]'),
             schoolNameHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-school-name-header"]'),
             urn: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-URN"]'),
@@ -39,6 +43,8 @@ class PipelineAcademies {
         },
         freeSchools: {
             section: () => cy.get('[data-testid="free-schools-table"]'),
+            table: () => this.elements.freeSchools.section().find('[aria-describedby="free-schools-caption"]'),
+            tableRows: () => this.elements.freeSchools.table().find('tbody tr'),
             schoolName: () => this.elements.freeSchools.section().find('[data-testid="free-schools-board-school-name"]'),
             schoolNameHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-school-name-header"]'),
             urn: () => this.elements.freeSchools.section().find('[data-testid="free-schools-URN"]'),
@@ -252,6 +258,23 @@ class PipelineAcademies {
         return this;
     }
 
+    public checkSchoolNamesAreCorrectLinksOnPreAdvisoryPage(): this {
+        TableUtility.checkSchoolNamesAreCorrectLinksOnPage(this.elements.preAdvisory, "pre-advisory-board-school-name", "pre-advisory-board-URN");
+        return this;
+    }
+
+    public checkSchoolNamesAreCorrectLinksOnPostAdvisoryPage(): this {
+        TableUtility.checkSchoolNamesAreCorrectLinksOnPage(this.elements.postAdvisory, "post-advisory-board-school-name", "post-advisory-board-URN");
+        return this;
+    }
+
+    public checkSchoolNamesAreNotLinksOnFreeSchools(): this {
+        this.elements.freeSchools.schoolName().each(element => {
+            expect(element.children('a').length).to.equal(0);
+            expect(element.text().trim()).to.not.be.empty;
+        });
+        return this;
+    }
 }
 
 const pipelineAcademiesPage = new PipelineAcademies();


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 224275](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/224275): Build: Transform academy name into hyperlink to academy record. Other branches for this feature should be merged into this one.

This updates the following pages so that academy names are links to the overview page for the academy:
- `/trusts/academies/in-trust/details`
- `/trusts/academies/in-trust/pupil-numbers`
- `/trusts/academies/in-trust/free-school-meals`
- `/trusts/academies/pipeline/pre-advisory-board`
- `/trusts/academies/pipeline/post-advisory-board`
- `/trusts/academies/pipeline/free-schools`
- `/trusts/ofsted/single-headline-grades`

It's worth noting that there are no free schools in the pipeline stage that have URNs, so in practice this page is unchanged. However, if such a school exists in the future, this page will also provide a link.

Additionally, for the Ofsted pages, only the single headline grades should have links; the other pages should just have the academy names as regular text, and have been unchanged.

## Changes

- A new `_AcademyLink` Razor partial and associated `AcademyLinkModel` record have been introduced to render the links in a consistent manner.
- The Razor pages for the above list have been updated to use this partial to render the academy name.

## Screenshots of UI changes

### Before

### After

Details - In this trust - Academies:
<img width="2127" height="4768" alt="" src="https://github.com/user-attachments/assets/2b29844a-beac-4215-9c8b-06434659d750" />

Pupil numbers - In this trust - Academies:
<img width="2127" height="3486" alt="" src="https://github.com/user-attachments/assets/cb312791-1709-49ad-9a44-931a6b2b1534" />

Free school meals - In this trust - Academies:
<img width="2127" height="3708" alt="" src="https://github.com/user-attachments/assets/8fb2154a-1ee9-4181-93ec-1fe38b1aa3b2" />

Pre advisory board - Pipeline academies - Academies:
<img width="2127" height="2742" alt="" src="https://github.com/user-attachments/assets/ba15fff7-1c85-44b2-96d0-f57c10a65a14" />

Post advisory board - Pipeline academies - Academies:
<img width="2127" height="2392" alt="" src="https://github.com/user-attachments/assets/45e57813-e911-49f5-9c2f-9ac9f4cce49d" />

Free schools - Pipeline academies - Academies (note that the academy names are not links as the URNs are not known):
<img width="2127" height="2529" alt="" src="https://github.com/user-attachments/assets/1999f53d-83bf-42b1-a33c-1e6a71e09955" />

Single headline grades - Ofsted:
<img width="2127" height="5025" alt="" src="https://github.com/user-attachments/assets/c1f9139a-3687-41b2-8522-95be1469fbdf" />


## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
