### PR TITLE
feature/Remove GIAS link from academy details table for trusts

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
@@ -8,8 +8,7 @@
 <section class="app-table-container">
   <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="details-caption">
     <caption class="govuk-table__caption govuk-table__caption--m" id="details-caption" data-testid="subpage-header">
-      Details <br/>
-      <span class="govuk-body-s">The following links open in a new tab</span>
+      Details
     </caption>
 
     <thead class="govuk-table__head">
@@ -20,7 +19,6 @@
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Local authority</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Type</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Rural or urban</th>
-        <th scope="col" class="govuk-body govuk-table__header">Get information about schools</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -37,11 +35,6 @@
           <td class="govuk-body govuk-table__cell" data-testid="local-authority">@academy.LocalAuthority</td>
           <td class="govuk-body govuk-table__cell" data-testid="type-of-establishment">@academy.TypeOfEstablishment</td>
           <td class="govuk-body govuk-table__cell" data-testid="urban-or-rural">@academy.UrbanRural</td>
-          <td class="govuk-body govuk-table__cell">
-            <a href="@Model.LinkBuilder.GetInformationAboutSchoolsListingLinkForSchool(academy.Urn)" class="govuk-link" rel="noreferrer noopener" target="_blank" aria-label="@academy.EstablishmentName on Get information about schools (opens in new tab)">
-              More information
-            </a>
-          </td>
         </tr>
       }
     </tbody>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml.cs
@@ -10,7 +10,6 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies.InTrust;
 
 public class AcademiesInTrustDetailsModel(
     IDataSourceService dataSourceService,
-    IOtherServicesLinkBuilder linkBuilder,
     ITrustService trustService,
     IAcademyService academyService,
     IAcademiesExportService academiesExportService,
@@ -27,8 +26,7 @@ public class AcademiesInTrustDetailsModel(
 
     public override PageMetadata PageMetadata => base.PageMetadata with { TabName = TabName };
 
-    public AcademyDetailsServiceModel[] Academies { get; set; } = default!;
-    public IOtherServicesLinkBuilder LinkBuilder { get; } = linkBuilder;
+    public AcademyDetailsServiceModel[] Academies { get; set; } = null!;
 
     public override async Task<IActionResult> OnGetAsync()
     {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/trust/trust-navigation-core.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/trust/trust-navigation-core.cy.ts
@@ -50,7 +50,8 @@ describe('Trust Navigation Core Tests', () => {
                     .checkCurrentURLIsCorrect('/trusts/academies/in-trust/details?uid=5527')
                     .checkAllServiceNavItemsPresent();
                 academiesInTrustPage
-                    .checkDetailsHeadersPresent();
+                    .checkDetailsHeadersPresent()
+                    .checkGiasHeaderNotPresent();
             });
 
             it('Should check that the Ofsted navigation button takes me to the Ofsted single headline grades page', () => {
@@ -198,7 +199,8 @@ describe('Trust Navigation Core Tests', () => {
                     .checkAllServiceNavItemsPresent()
                     .checkAllAcademiesNavItemsPresent();
                 academiesInTrustPage
-                    .checkDetailsHeadersPresent();
+                    .checkDetailsHeadersPresent()
+                    .checkGiasHeaderNotPresent();
             });
 
             it('Should check that the academies sub nav items are not present when I am not in the relevant academies page', () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
@@ -16,7 +16,8 @@ describe("Testing the components of the Academies page", () => {
 
         it("Checks the correct details page headers are present", () => {
             academiesInTrustPage
-                .checkDetailsHeadersPresent();
+                .checkDetailsHeadersPresent()
+                .checkGiasHeaderNotPresent();
         });
 
         it("Checks that the correct school types are present", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
@@ -106,8 +106,7 @@ class AcademiesInTrustPage {
             .and('contain', 'URN')
             .and('contain', 'Local authority')
             .and('contain', 'Type')
-            .and('contain', 'Rural or urban')
-            .and('contain', 'Get information about schools');
+            .and('contain', 'Rural or urban');
         return this;
     }
     
@@ -124,6 +123,11 @@ class AcademiesInTrustPage {
     public checkSchoolNamesAreCorrectLinksOnFreeSchoolMealsPage(): this {
         TableUtility.checkSchoolNamesAreCorrectLinksOnPage(this.elements.freeSchoolMeals, "school-name", "urn");
         return this;
+    }
+    
+    public checkGiasHeaderNotPresent(): this {
+        const { detailsPage } = this.elements;
+        detailsPage.table().should('not.contain', 'Get information about schools');
     }
 
     public checkPupilNumbersHeadersPresent(): this {

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
@@ -11,18 +11,11 @@ public class AcademiesDetailsModelTests : AcademiesInTrustAreaModelTests<Academi
     public AcademiesDetailsModelTests()
     {
         Sut = new AcademiesInTrustDetailsModel(MockDataSourceService,
-                _mockLinkBuilder,
                 MockTrustService,
                 MockAcademyService,
                 MockAcademiesExportService,
                 MockDateTimeProvider)
             { Uid = TrustUid };
-    }
-
-    [Fact]
-    public void OtherServicesLinkBuilder_should_be_injected()
-    {
-        Sut.LinkBuilder.Should().Be(_mockLinkBuilder);
     }
 
     [Fact]


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 224274](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/224274): Build: Remove GIAS link from Academies table. Other branches for this feature should be merged into this one.

This PR updates the details tab on the 'academies in this trust' page to remove the last column on the table, which contained links to Get information about schools, as this link will become obsolete due to the changes in #903.

<!-- Add a link to the user story -->

<!-- Do you need to add any environment variables? -->

## Changes

- The `Details.cshtml` Razor view no longer includes a column for the GIAS link.
- The `AcademiesInTrustDetailsModel` class no longer requires or exposes an instance of `IOtherServicesLinkBuilder` as it's no longer required.

## Screenshots of UI changes

The academies table no longer has a link to GIAS (note that the links to academy information is not included here but is introduced in #903):
<img width="100%" height="100%" alt="" src="https://github.com/user-attachments/assets/e8e8b376-8857-4920-bf2c-529bb59f658b" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
