### PR TITLE
Adjust width for `.column-header-date`

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -24,7 +24,7 @@
   }
 
   .column-header-date {
-    width: 12%;
+    width: 13%;
   }
 
   .column-header-ofsted-single-headline-grade {


### PR DESCRIPTION
This makes this table column very slightly wider so that in the trust academies table, the text in the 'Date joined trust' column header only spans two lines instead of three.

## Screenshots of UI changes

### Before
<img width="100%" height="100%" alt="" src="https://github.com/user-attachments/assets/a69b7b71-e1e9-4266-a7a2-c89edccaa542" />

### After
<img width="100%" height="100%" alt="" src="https://github.com/user-attachments/assets/dc8493a7-9f97-4aab-98e4-407bc41c67ac" />


## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
