### PR TITLE
Improve display of short inspection outcomes

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Extensions/OfstedShortInspectionExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/OfstedShortInspectionExtensions.cs
@@ -1,0 +1,15 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.Extensions;
+
+public static class OfstedShortInspectionExtensions
+{
+    public static string ToOutcomeDisplayString(this OfstedShortInspection shortInspection) =>
+        shortInspection.InspectionOutcome switch
+        {
+            null => "Not available",
+            var o when o.Trim() == string.Empty => "Not available",
+            var o when o.Contains('-') => o.Split('-')[0].Trim(),
+            _ => shortInspection.InspectionOutcome
+        };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
@@ -68,7 +68,7 @@
                 <tr class="govuk-table__row" data-testid="recent-short-inspection-row">
                     <th scope="row" class="govuk-table__cell">Recent short inspection</th>
                         <td class="govuk-table__cell" data-testid="recent-short-inspection-date">@Model.HeadlineGrades.ShortInspection.InspectionDate.ShowFullDateStringOrReplaceWithText("Not available")</td>
-                    <td class="govuk-table__cell" data-testid="recent-short-inspection-grade">@Model.HeadlineGrades.ShortInspection.InspectionOutcome</td>
+                    <td class="govuk-table__cell" data-testid="recent-short-inspection-grade">@Model.HeadlineGrades.ShortInspection.ToOutcomeDisplayString()</td>
                 </tr>
             }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/OfstedShortInspectionExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/OfstedShortInspectionExtensionsTests.cs
@@ -1,0 +1,21 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Extensions;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Extensions;
+
+public class OfstedShortInspectionExtensionsTests
+{
+    [Theory]
+    [InlineData(null, "Not available")]
+    [InlineData("   \t\t    \t", "Not available")]
+    [InlineData("School remains Good (Improving) - S5 Next", "School remains Good (Improving)")]
+    [InlineData("School remains Outstanding", "School remains Outstanding")]
+    public void ToOutcomeDisplayString_returns_correct_display_value(string? outcome, string expected)
+    {
+        var shortInspection = new OfstedShortInspection(DateTime.Now, outcome);
+
+        var result = shortInspection.ToOutcomeDisplayString();
+        
+        result.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [Bug 231064](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/231064): [BUG] Ofsted - remove unneeded text from grade. Other branches for this feature should be merged into this one.

Currently, short inspection outcomes are free text. This results in multiple instances where a grade is given with some additional information, such as "School remains Good (improving) - S5 Next".

Users have identified that they don't need this additional information and would prefer to see "School remains Good (improving)" in this case. This change introduces handling for these cases to strip this unneeded extra information.

Additionally, in situations where a short inspection date exists but the outcome is `null`, the page currently displays nothing. This change introduces a check for this case so that "Not available" is displayed instead.

Otherwise, the short inspection grade is displayed the same as it was previously.

## Screenshots of UI changes

### Before
A short inspection with a `null` grade is displayed as an empty string:
<img width="2419" height="2578" alt="" src="https://github.com/user-attachments/assets/e6d7ff43-6352-4fbb-9435-74a59c5a87eb" />

A short inspection with no unnecessary information in the grade:
<img width="2419" height="2523" alt="" src="https://github.com/user-attachments/assets/26a6f970-a157-4fde-968f-065b9da04c8b" />

A short inspection with additional information in the grade:
<img width="2419" height="2572" alt="" src="https://github.com/user-attachments/assets/540ef6e1-ee59-414f-aa7b-0e3f89f29aa3" />

### After
A short inspection with a `null` grade is displayed as "Not available":
<img width="2419" height="2578" alt="" src="https://github.com/user-attachments/assets/772aa8ae-20f7-4d47-b11f-9bb539ff564c" />

A short inspection with no unnecessary information in the grade is unchanged:
<img width="2419" height="2523" alt="" src="https://github.com/user-attachments/assets/06185ca0-f082-4589-b15a-7ced77346fd2" />

A short inspection with additional information in the grade has had the extra information removed:
<img width="2419" height="2458" alt="" src="https://github.com/user-attachments/assets/6d02748d-13f7-4152-9e2b-aec8590321d6" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
