### PR TITLE
[233129] oftsed external link

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -82,7 +82,7 @@
 
         <hr class="govuk-section-break govuk-section-break--m">
         
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted</a>.</p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (opens in new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -82,7 +82,7 @@
 
         <hr class="govuk-section-break govuk-section-break--m">
         
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in new tab)</a> </p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in a new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -82,7 +82,7 @@
 
         <hr class="govuk-section-break govuk-section-break--m">
         
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (opens in new tab)</a> </p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
@@ -88,7 +88,7 @@
 
         <hr class="govuk-section-break govuk-section-break--m">
 
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted</a>.</p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (opens in new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
@@ -88,7 +88,7 @@
 
         <hr class="govuk-section-break govuk-section-break--m">
 
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (opens in new tab)</a> </p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
@@ -88,7 +88,7 @@
 
         <hr class="govuk-section-break govuk-section-break--m">
 
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in new tab)</a> </p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in a new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
@@ -98,7 +98,7 @@
         
         <hr class="govuk-section-break govuk-section-break--m">
 
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted</a>.</p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (opens in new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
@@ -98,7 +98,7 @@
         
         <hr class="govuk-section-break govuk-section-break--m">
 
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (opens in new tab)</a> </p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
@@ -98,7 +98,7 @@
         
         <hr class="govuk-section-break govuk-section-break--m">
 
-        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in new tab)</a> </p>
+        <p class="govuk-body"><a class="govuk-link" href="@Model.OfstedReportUrl" rel="noreferrer noopener" target="_blank" data-testid="ofsted-inspection-reports-link">See the inspection reports at Ofsted (Opens in a new tab)</a> </p>
 
         <hr class="govuk-section-break govuk-section-break--m">
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolOfstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolOfstedPage.ts
@@ -169,8 +169,10 @@ class SchoolOfstedPage {
 
     public checkInspectionReportsLinkValid(): this {
         this.elements.singleHeadlineGrades.inspectionReportsLink()
-            .should('have.attr', 'href')
-            .and('match', /^https:\/\/reports\.ofsted\.gov\.uk/);
+        .should(($a) => {
+            expect($a).to.have.attr('href').match(/^https:\/\/reports\.ofsted\.gov\.uk/);
+            expect($a).to.have.attr('target', '_blank');
+        });
         return this;
     }
 


### PR DESCRIPTION
Changed the external link to oftsed to open in a new tab and added the wording (Opens in new tab)

## Screenshots of UI changes

### Before

<img width="914" height="217" alt="image" src="https://github.com/user-attachments/assets/51fd9b7b-b261-4028-8b8c-56baaa1a2696" />


### After

<img width="840" height="259" alt="image" src="https://github.com/user-attachments/assets/0f6d1884-5b9d-44a0-9176-43b2c17cb7e2" />


## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] Testing complete - all manual and automated tests pass
