### PR TITLE
Add 'About the data we use' page

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/AboutData.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/AboutData.cshtml
@@ -1,0 +1,152 @@
+@page
+@model DfE.FindInformationAcademiesTrusts.Pages.Shared.ContentPageModel
+
+@{
+  Model.ShowBreadcrumb = false;
+  Model.BannerHeading = "About the data we use";
+  Layout = "_ContentLayout";
+  ViewData["Title"] = Model.BannerHeading;
+}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <!--Intro copy-->
+    <p class="govuk-body">
+      Find information about schools and trusts (FAST) brings together data from different places. 
+    </p>
+
+    <p class="govuk-body">
+      We do not own the information we show from other services. 
+    </p>
+
+    <p class="govuk-body">
+      This means we cannot:
+    </p>
+
+    <!--Bullets - what this means-->
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        control its quality
+      </li>
+      <li>
+        make changes to it
+      </li>
+      <li>
+        remove or replace it
+      </li>
+    </ul>
+
+    <!--Intro copy 2 -->
+    <p class="govuk-body">
+      To report a problem with data taken from another source, you must contact the service responsible for it. 
+    </p>
+
+    <!--h2 When we fetch data-->
+    <h2 class="govuk-heading-m">How FAST gets updated</h2>
+
+    <!--Inset text-->
+    <div class="govuk-inset-text">
+      When we talk about updating FAST, we mean replacing the data it holds with a new copy from whoever maintains it.
+    </div>
+
+    <!--When we fetch data para -->
+    <p class="govuk-body">
+      If there are changes that FAST needs to reflect, providing the place we take the data from has been updated, you should see them the next time we take a copy.
+    </p> 
+
+    <p class="govuk-body">
+      We do this as often as we can so that the information you see is as up to date as possible. 
+    </p>
+
+    <!--h3 daily-->
+    <h3 class="govuk-heading-s">Things we update daily</h3>
+
+    <!--Daily paras -->
+    <p class="govuk-body">
+      Most FAST information comes from <a class="govuk-link" href="https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/RSD.aspx">Regions Group tools and systems</a> or <a class="govuk-link" href="https://get-information-schools.service.gov.uk/">Get information about schools (GIAS)</a> and gets updated <strong>every morning</strong>. 
+    </p>
+
+    <p class="govuk-body">
+      This includes:
+    </p>
+
+    <!--Daily morning bullets-->
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+      names, addresses and reference numbers
+      </li>
+      <li>
+      current academies in a trust 
+      </li>
+      <li>
+      details of any academies in the pipeline
+      </li>
+    </ul>
+
+    <!--h3 Spring census updates-->
+    <h3 class="govuk-heading-s">Spring census data</h3>
+
+    <!--Spring census para -->
+    <p class="govuk-body">
+    Some information we take from GIAS comes from the Spring census. This gets updated <strong>every year</strong> and includes:
+    </p>
+
+    <!--Spring census bullets-->
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+      pupil numbers
+      </li>
+      <li>
+      free school meals figures
+      </li>
+    </ul>
+
+    <!--h3 Ofsted data-->
+    <h3 class="govuk-heading-s">Ofsted reports</h3>
+
+    <!--Ofsted data para -->
+    <p class="govuk-body">
+      We take most Ofsted information from: 
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <a class="govuk-link" href="https://www.gov.uk/government/collections/maintained-schools-and-academies-inspections-and-outcomes-official-statistics">
+          State-funded schools statistics: management information
+        </a>
+      </li>
+      <li>
+        <a class="govuk-link" href="https://www.gov.uk/government/collections/further-education-and-skills-inspection-outcomes#monthly-inspection-data">
+          Further education and skills inspections: management information
+        </a>
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      Both reports are upated <strong>every month</strong>.
+    </p> 
+
+    <p class="govuk-body">
+      Adding the monthly data is a manual process and we cannot give an exact date for when it will be visible in FAST.
+    </p>
+
+    <p class="govuk-body">
+      Ofsted may publish school inspection reports on their website between monthly updates.
+    </p>
+
+    <p class="govuk-body">
+      We add the new report data for these schools <strong>every week</strong>. The data for this is sent to us directly from Ofsted. 
+    </p>
+
+    <!--h3 Other data-->
+    <h3 class="govuk-heading-s">Other data we use</h3>
+
+    <p class="govuk-body">
+      Financial documents that trusts submit to us each year are held and maintained by the Regions Group Data Science team.
+    </p>
+
+    <p class="govuk-body">
+      We also take some statistical information from <a class="govuk-link" href="https://explore-education-statistics.service.gov.uk/">Explore education statistics</a> which is published every year.
+    </p>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/ContentPageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/ContentPageModel.cs
@@ -1,6 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
 
+[ExcludeFromCodeCoverage(Justification = "Class with no behaviour and only used by Razor pages")]
 public class ContentPageModel : BasePageModel
 {
     public bool ShowBreadcrumb { get; set; } = true;
+    public string? BannerHeading { get; set; }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/_SourceList.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/_SourceList.cshtml
@@ -24,6 +24,9 @@
           }
         </ul>
       }
+      <a class="govuk-link" asp-page="/AboutData" target="_blank" rel="noopener noreferrer" data-testid="data-source-more-info-link">
+        More about the data we use (opens in a new tab)
+      </a>
     </div>
   </details>
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ContentLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ContentLayout.cshtml
@@ -4,6 +4,18 @@
   Layout = "_Layout";
 }
 
+@if (Model.BannerHeading is not null)
+{
+  <div class="app-banner" data-testid="aboutdata-header">
+    <div class="dfe-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+          <h1 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3">@Model.BannerHeading</h1>
+        </div>
+      </div>
+    </div>
+  </div>
+}
 <div class="govuk-main-wrapper @(Model.ShowBreadcrumb ? "govuk-!-padding-top-0" : "govuk-!-padding-top-6")">
   <div class="dfe-width-container">
     @if (Model.ShowBreadcrumb)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
@@ -58,6 +58,9 @@
           <li class="govuk-footer__inline-list-item">
             <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-footer-link">Privacy notice</a>
           </li>
+          <li class="govuk-footer__inline-list-item">
+            <a asp-page="/AboutData" class="govuk-footer__link" data-testid="about-data-footer-link">Learn more about the data we use</a>
+          </li>
         </ul>
         <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg"
              viewBox="0 0 483.2 195.7" height="17" width="41">

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/accessibility/components/navigation-accessibility.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/accessibility/components/navigation-accessibility.cy.ts
@@ -48,7 +48,7 @@ describe('Navigation Accessibility', () => {
                 });
             });
 
-            ['/', '/error'].forEach((url) => {
+            ['/', '/error', '/aboutdata'].forEach((url) => {
                 it(`Should have accessible page structure without breadcrumb on ${url}`, () => {
                     cy.visit(url);
 
@@ -155,6 +155,7 @@ describe('Navigation Accessibility', () => {
 
         // Use navigation POM to check footer links
         navigation
+            .checkAboutDataLinkPresent()
             .checkPrivacyLinkPresent()
             .checkCookiesLinkPresent()
             .checkAccessibilityStatementLinkPresent();

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/accessibility/comprehensive-accessibility-audit.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/accessibility/comprehensive-accessibility-audit.cy.ts
@@ -8,7 +8,7 @@ import { AuditPageDefinitions } from '../../support/audit-page-definitions';
  * Comprehensive Accessibility Audit Report Generator
  * 
  * Generates ONE comprehensive HTML audit report covering ALL application areas:
- * - Core pages (home, search, cookies, accessibility, privacy)
+ * - Core pages (home, search, cookies, accessibility, privacy, about data)
  * - Trust pages (all overview, contacts, governance, ofsted, academies, financial subpages)
  * - School pages (all overview, contacts, SEN, federation subpages)
  * 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/data-sources.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/data-sources.cy.ts
@@ -5,7 +5,7 @@ import { TestDataStore } from "../../support/test-data-store";
 describe("Testing the data sources component", () => {
 
     describe("Content pages", () => {
-        ['/', '/search', '/accessibility', '/cookies', '/privacy', '/error'].forEach((url) => {
+        ['/', '/search', '/accessibility', '/cookies', '/privacy', '/error', '/aboutdata'].forEach((url) => {
             it(`Should not have a data sources component on ${url}`, () => {
                 cy.visit(url); // don't turn off fail on status code because we want the test to fail if visit returns 404 as that means our test urls are incorrect
 
@@ -41,7 +41,8 @@ describe("Testing the data sources component", () => {
                         // Check that the data sources component has a subheading for each subnav
                         commonPage
                             .checkHasDataSourcesComponent()
-                            .checkDataSourcesComponentHasSubpageHeadings(subpageNames);
+                            .checkDataSourcesComponentHasSubpageHeadings(subpageNames)
+                            .checkDataSourcesHasLinkToAboutDataPage();
                     });
                 });
             });
@@ -66,7 +67,8 @@ describe("Testing the data sources component", () => {
 
                         commonPage
                             .checkHasDataSourcesComponent()
-                            .checkDataSourcesComponentHasSubpageHeadings(expectedHeadings);
+                            .checkDataSourcesComponentHasSubpageHeadings(expectedHeadings)
+                            .checkDataSourcesHasLinkToAboutDataPage();
                     });
                 });
             });
@@ -86,7 +88,8 @@ describe("Testing the data sources component", () => {
 
                         commonPage
                             .checkHasDataSourcesComponent()
-                            .checkDataSourcesComponentHasSubpageHeadings(expectedHeadings);
+                            .checkDataSourcesComponentHasSubpageHeadings(expectedHeadings)
+                            .checkDataSourcesHasLinkToAboutDataPage();
                     });
                 });
             });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/general/breadcrumb-links.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/general/breadcrumb-links.cy.ts
@@ -15,7 +15,7 @@ describe('Testing breadcrumb functionality across FAST', () => {
             });
         });
 
-        ['/', '/error'].forEach((url) => {
+        ['/', '/error', '/aboutdata'].forEach((url) => {
             it(`Should have no breadcrumb on ${url}`, () => {
                 cy.visit(url);
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/general/footer-links-nav.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/general/footer-links-nav.cy.ts
@@ -6,6 +6,16 @@ describe('Testing Navigation', () => {
         beforeEach(() => {
             cy.visit('/');
         });
+        
+        it("Should check that the home page footer bar 'Learn more about the data we use' link is present and functional", () => {
+            navigation
+                .checkAboutDataLinkPresent()
+                .clickAboutDataLink();
+
+            navigation
+                .checkCurrentURLIsCorrect('aboutdata');
+
+        });
 
         it("Should check that the home page footer bar privacy link is present and functional", () => {
             navigation

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/financial-docs.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/financial-docs.cy.ts
@@ -134,7 +134,8 @@ testFinanceData.forEach(({ uid }) => {
                 it(`Should have an about these documents component and the correct information on ${url}`, () => {
                     financialDocumentsPage
                         .checkHasAboutTheseDocumentsComponent()
-                        .checkAboutTheseDocumentsComponentDetails();
+                        .checkAboutTheseDocumentsComponentDetails()
+                        .checkAboutTheseDocumentsDoesNotHaveAboutDataLink();
                 });
 
                 it('Should have the correct permission message', () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
@@ -92,6 +92,13 @@ class CommonPage {
 
         return this;
     }
+    
+    public checkDataSourcesHasLinkToAboutDataPage(): this {
+        const { dataSources } = this.elements;
+        dataSources.section().find('[data-testid="data-source-more-info-link"]').should('be.visible');
+        dataSources.section().find('[data-testid="data-source-more-info-link"]').should('have.attr', 'href', '/aboutdata');
+        return this;   
+    }
 
     public checkPageContentHasLoaded(): this {
         const { elementPresentOnEveryPage } = this.elements;

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/navigation.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/navigation.ts
@@ -4,6 +4,7 @@ class Navigation {
         privacyFooterButton: () => cy.contains('Privacy'),
         cookiesFooterButton: () => cy.get('[data-testid="cookies-footer-link"]'),
         accessibilityFooterButton: () => cy.contains('Accessibility'),
+        aboutDataFooterButton: () => cy.get('[data-testid="about-data-footer-link"]'),
         academyTypeNav: {
             inThisTrustButton: () => cy.get('[data-testid="academies-in-this-trust-subnav"]'),
             pipelineAcademiesButton: () => cy.get('[data-testid="academies-pipeline-academies-subnav"]'),
@@ -93,6 +94,16 @@ class Navigation {
 
     public checkCurrentURLIsCorrect(urlPageName: string): this {
         cy.url().should('include', urlPageName);
+        return this;
+    }
+    
+    public checkAboutDataLinkPresent(): this {
+        this.elements.aboutDataFooterButton().scrollIntoView().should('be.visible');
+        return this;
+    }
+    
+    public clickAboutDataLink(): this {
+        this.elements.aboutDataFooterButton().scrollIntoView().click();
         return this;
     }
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/financialDocumentsPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/financialDocumentsPage.ts
@@ -96,6 +96,14 @@ class FinancialDocuments {
 
         return this;
     }
+    
+    public checkAboutTheseDocumentsDoesNotHaveAboutDataLink(): this {
+        this.elements.aboutTheseDocuments().expandDetailsElement();
+        
+        this.elements.aboutTheseDocuments().find('a[href="/aboutdata"]').should('not.exist');
+        
+        return this;
+    }
 
     public checkForCorrectInternalUseMessage(internalUseMessage: string): this {
         this.elements.internalUseOnlyMessage().should('contain.text', internalUseMessage);

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/audit-page-definitions.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/audit-page-definitions.ts
@@ -14,6 +14,7 @@ export class AuditPageDefinitions {
         this.auditHelper.auditPage('Cookies Policy', 'Core', '/cookies');
         this.auditHelper.auditPage('Accessibility Statement', 'Core', '/accessibility');
         this.auditHelper.auditPage('Privacy Policy', 'Core', '/privacy');
+        this.auditHelper.auditPage('About the data we use', 'Core', '/aboutdata');
     }
 
     /**


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 203478](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/203478): Backlog - Build: data sources 'explainer page'. Other branches for this feature should be merged into this one.

This page explains where and how often FAST retrieves data.

Links to this page are available in the page footer and within the 'Where this information came from' section. It is not provided for the 'About these documents' section in the Financial documents area for a trust.

The page uses the `_ContentLayout` partial in a similar way to the privacy notice, accessibility statement, and cookie consent form, but requires a banner heading. This has been implemented by creating a new `BannerHeading` property on the `ContentPageModel`, which when non-null, will display the heading in a banner.

## Changes
- A new `AboutData.cshtml` Razor page has been introduced.
- The `_ContentLayout` partial has been updated to optionally render a banner heading when the `ContentPageModel`'s new `BannerHeading` property is non-null. This approach means that the other content pages can be easily migrated in the future should these need to be changed to match.
- The `_SourceList.cshtml` and `_Footer.cshtml` partials have been updated to provide a link to the new page.

## Screenshots of UI changes

### Before
No link is present within the 'Where this information came from' section or in the footer:
<img width="2419" height="2509" alt="" src="https://github.com/user-attachments/assets/3d2be130-ace8-45cb-b0dd-bd6f85b578a4" />

### After
Links are present both in the 'Where this information came from' section and in the footer:
<img width="2419" height="3024" alt="" src="https://github.com/user-attachments/assets/88a57c84-3b1b-4cf9-af56-8afea724ec40" />

The 'About the data we use' page itself:
<img width="2419" height="3756" alt="" src="https://github.com/user-attachments/assets/f8692927-7ed6-4ed8-b69b-20b06c640b71" />


## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
