### PR TITLE
Update and enable governance turnover calculation

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustGovernanceRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustGovernanceRepository.cs
@@ -1,0 +1,34 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+
+public class TrustGovernanceRepository(
+    IAcademiesDbContext dbContext,
+    IStringFormattingUtilities stringFormattingUtilities
+) : ITrustGovernanceRepository
+{
+    public Task<List<Governor>> GetTrustGovernanceAsync(string uidOrUrn)
+    {
+        return dbContext.GiasGovernances
+            .Where(governance => governance.Uid == uidOrUrn || governance.Urn == uidOrUrn)
+            .Select(governance => new Governor(
+                governance.Gid!,
+                governance.Uid!,
+                stringFormattingUtilities.GetFullName(
+                    governance.Forename1!,
+                    governance.Forename2!,
+                    governance.Surname!
+                ),
+                governance.Role!,
+                governance.AppointingBody!,
+                governance.DateOfAppointment.ParseAsNullableDate(),
+                governance.DateTermOfOfficeEndsEnded.ParseAsNullableDate(),
+                null
+            ))
+            .ToListAsync();
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
@@ -68,33 +68,6 @@ public class TrustRepository(
         return trustOverview;
     }
 
-    public async Task<TrustGovernance> GetTrustGovernanceAsync(string uid, string? urn = null)
-    {
-        IQueryable<GiasGovernance> query = academiesDbContext.GiasGovernances;
-
-        var governors = await FilterBySatOrMat(uid, urn, query)
-            .Select(governance => new Governor(
-                governance.Gid!,
-                governance.Uid!,
-                stringFormattingUtilities.GetFullName(governance.Forename1!, governance.Forename2!,
-                    governance.Surname!),
-                governance.Role!,
-                governance.AppointingBody!,
-                governance.DateOfAppointment.ParseAsNullableDate(),
-                governance.DateTermOfOfficeEndsEnded.ParseAsNullableDate(),
-                null))
-            .ToArrayAsync();
-
-        var governersDto = new TrustGovernance(
-            governors.Where(g => g.IsCurrentOrFutureGovernor && g.HasRoleLeadership).ToArray(),
-            governors.Where(g => g.IsCurrentOrFutureGovernor && g.HasRoleMember).ToArray(),
-            governors.Where(g => g.IsCurrentOrFutureGovernor && g.HasRoleTrustee).ToArray(),
-            governors.Where(g => !g.IsCurrentOrFutureGovernor).ToArray()
-        );
-
-        return governersDto;
-    }
-
     public static IQueryable<GiasGovernance> FilterBySatOrMat(string uid, string? urn, IQueryable<GiasGovernance> query)
     {
         if (!string.IsNullOrEmpty(urn))

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Governor.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Governor.cs
@@ -24,5 +24,5 @@ public record Governor(
 
     private bool HasRoleChiefFinancialOfficer => Role == "Chief Financial Officer";
 
-    private bool HasRoleChairOfTrustees => Role == "Chair of Trustees";
+    public bool HasRoleChairOfTrustees => Role == "Chair of Trustees";
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustGovernanceRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustGovernanceRepository.cs
@@ -1,0 +1,6 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
+
+public interface ITrustGovernanceRepository
+{
+    Task<List<Governor>> GetTrustGovernanceAsync(string uidOrUrn);
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
@@ -4,7 +4,6 @@ public interface ITrustRepository
 {
     Task<TrustSummary?> GetTrustSummaryAsync(string uid);
     Task<TrustOverview> GetTrustOverviewAsync(string uid);
-    Task<TrustGovernance> GetTrustGovernanceAsync(string uid, string? urn = null);
     Task<TrustContacts> GetTrustContactsAsync(string uid, string? urn = null);
     Task<string> GetTrustReferenceNumberAsync(string uid);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/TrustGovernance.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/TrustGovernance.cs
@@ -1,7 +1,0 @@
-﻿namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
-
-public record TrustGovernance(
-    Governor[] CurrentTrustLeadership,
-    Governor[] CurrentMembers,
-    Governor[] CurrentTrustees,
-    Governor[] HistoricMembers);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/_GovernanceTurnover.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/_GovernanceTurnover.cshtml
@@ -1,15 +1,33 @@
 ﻿@using DfE.FindInformationAcademiesTrusts.Configuration
 @model GovernanceAreaModel
 <feature name="@FeatureFlags.GovernanceTurnover">
-<div class="govuk-summary-card">
-  <div class="govuk-summary-card__title-wrapper">
-    <h2 class="govuk-summary-card__title">Governance turnover</h2>
-  </div>
-  <div class="govuk-summary-card__content">
-    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-top-2 govuk-!-margin-bottom-2">
-      @Model.TrustGovernance.TurnoverRate.ToString("0.#")% within the last 12 months
+  <div class="govuk-inset-text govuk-!-margin-top-0">
+    <p class="govuk-body govuk-!-font-weight-bold" data-testid="turnover-rate-headline">
+      The governance turnover rate is @Model.TrustGovernance.TurnoverRate.ToString("0.#")% within the last 12 months
     </p>
-    <p class="govuk-body">Governance turnover % is calculated based on the total number of appointments and resignations in the past calendar year, divided by the total number of current governors.</p>
+    <p class="govuk-body" data-testid="turnover-rate-summary">
+      This is the number of trustees appointed or resigned as a proportion of the number of trustees on the board.
+    </p>
   </div>
-</div>
+  <details class="govuk-details" data-testid="turnover-calculation-explanation">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        How governance turnover is calculated
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <p class="govuk-body">Governance turnover % is calculated based on the total number of appointments and resignations in the past calendar year, divided by the total number of current governors.</p>
+      <p class="govuk-body">This calculation includes:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Chair of Trustees</li>
+        <li>Trustees</li>
+      </ul>
+      <p class="govuk-body">This calculation <span class="govuk-!-font-weight-bold">does not</span> include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Accounting Officer</li>
+        <li>Chief Financial Officer</li>
+        <li>Members</li>
+      </ul>
+    </div>
+  </details>
 </feature>

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -80,6 +80,7 @@ public static class Dependencies
         builder.Services.AddScoped<IAcademyRepository, AcademyRepository>();
         builder.Services.AddScoped<IOfstedRepository, OfstedRepository>();
         builder.Services.AddScoped<ITrustRepository, TrustRepository>();
+        builder.Services.AddScoped<ITrustGovernanceRepository, TrustGovernanceRepository>();
         builder.Services.AddScoped<IDataSourceRepository, DataSourceRepository>();
         builder.Services.AddScoped<IFiatDataSourceRepository, FiatDataSourceRepository>();
         builder.Services.AddScoped<IContactRepository, ContactRepository>();

--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -41,7 +41,7 @@
   "FeatureManagement": {
     "TestFlag": false,
     "UpdatedFooterHelpLink": true,
-    "GovernanceTurnover": false,
+    "GovernanceTurnover": true,
     "ContactsInDfeForSchools": true
   },
   "DataProtection": {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -116,6 +116,36 @@ describe("Testing the components of the Governance page", () => {
                 cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
                 governancePage.checkHistoricMembersLinkValueMatchesNumberOfHistoricMembers();
             });
+            
+            it("Governor turnover rate information is displayed", () => {
+                cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+
+                cy.visit(`/trusts/governance/trustees?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+
+                cy.visit(`/trusts/governance/members?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+
+                cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+            });
         });
     });
 
@@ -154,6 +184,35 @@ describe("Testing the components of the Governance page", () => {
                 governancePage.checkHistoricMembersSubnavButtonHasZeroInBrackets();
             });
 
+            it("Governor turnover rate information is displayed", () => {
+                cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+
+                cy.visit(`/trusts/governance/trustees?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+
+                cy.visit(`/trusts/governance/members?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+
+                cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
+                governancePage
+                    .checkTurnoverRateIsPresent()
+                    .checkTurnoverRateSummaryIsPresent()
+                    .checkTurnoverCalculationExplanationIsPresent()
+                    .checkTurnoverCalculationExplanationDetails();
+            });
         });
     });
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/governancePage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/governancePage.ts
@@ -66,6 +66,11 @@ class GovernancePage {
         subHeaders: {
             subHeader: () => cy.get('[data-testid="subpage-header"]')
         },
+        turnover: {
+            rateHeadline: () => cy.get('[data-testid="turnover-rate-headline"]'),
+            rateSummary: () => cy.get('[data-testid="turnover-rate-summary"]'),
+            calculationExplanation: () => cy.get('[data-testid="turnover-calculation-explanation"]'),
+        }
     };
 
     // *************
@@ -256,6 +261,49 @@ class GovernancePage {
         this.elements.trustLeadership.roles().each(element => {
             expect(element.text().trim()).to.be.oneOf(["Chief Financial Officer", "Accounting Officer", "Chair of Trustees"]);
         });
+        return this;
+    }
+    
+    // ***********
+    //
+    // TURNOVER CHECKS
+    //
+    // ***********
+    
+    public checkTurnoverRateIsPresent(): this {
+        this.elements.turnover.rateHeadline().should('be.visible');
+        return this;
+    }
+    
+    public checkTurnoverRateSummaryIsPresent(): this {
+        this.elements.turnover.rateSummary().should('be.visible');
+        return this;
+    }
+    public checkTurnoverCalculationExplanationIsPresent(): this {
+        this.elements.turnover.calculationExplanation().should('be.visible');
+        return this;
+    }
+
+    public checkTurnoverCalculationExplanationDetails(): this {
+        // Expand the details element so we can see its contents on any screenshots if this fails
+        this.elements.turnover.calculationExplanation().expandDetailsElement();
+
+        // Check for the presence of each line of text
+        const expectedTexts = [
+            "Governance turnover % is calculated based on the total number of appointments and resignations in the past calendar year, divided by the total number of current governors.",
+            "This calculation includes:",
+            "Chair of Trustees",
+            "Trustees",
+            "This calculation does not include:",
+            "Accounting Officer",
+            "Chief Financial Officer",
+            "Members",
+        ];
+
+        expectedTexts.forEach(text => {
+            this.elements.turnover.calculationExplanation().contains(text).should('exist');
+        });
+
         return this;
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustGovernanceRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustGovernanceRepositoryTests.cs
@@ -1,0 +1,94 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Tad;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
+
+public class TrustGovernanceRepositoryTests
+{
+    private readonly TrustGovernanceRepository _sut;
+    private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
+    private readonly IStringFormattingUtilities _stringFormattingUtilities = new StringFormattingUtilities();
+    
+    private readonly DateTime _lastYear = DateTime.Today.AddYears(-1);
+    private readonly DateTime _nextYear = DateTime.Today.AddYears(1);
+
+    public TrustGovernanceRepositoryTests()
+    {
+        _sut = new TrustGovernanceRepository(_mockAcademiesDbContext.Object, _stringFormattingUtilities);
+    }
+
+    [Fact]
+    public async Task GetTrustGovernanceAsync_should_return_empty_list_when_no_governors_exist_for_uid_or_urn()
+    {
+        var result = await _sut.GetTrustGovernanceAsync("1234");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTrustGovernanceAsync_should_return_only_governors_for_that_uid_or_urn()
+    {
+        var unexpectedGovernor1 = CreateGovernor("9876", "9999", _lastYear, _nextYear);
+        var unexpectedGovernor2 = CreateGovernor("9876", "9999", _lastYear, _nextYear);
+        var expectedGovernor = CreateGovernor("1234", "9999", _lastYear, _nextYear);
+        
+        var result = await _sut.GetTrustGovernanceAsync("1234");
+        
+        result.Should().NotContain(unexpectedGovernor1);
+        result.Should().NotContain(unexpectedGovernor2);
+        result.Should().Contain(expectedGovernor);
+    }
+
+    private Governor CreateGovernor(
+        string uid,
+        string gid,
+        DateTime? startDate,
+        DateTime? endDate,
+        string role = "Member",
+        string forename1 = "First",
+        string forename2 = "Second",
+        string surname = "Last",
+        string appointingBody = "Some Org")
+    {
+        var fullName = string.Join(
+            ' ',
+            new List<string> { forename1, forename2, surname }.Where(n => !string.IsNullOrWhiteSpace(n))
+        );
+
+        var giasGovernance = new GiasGovernance
+        {
+            Gid = gid,
+            Uid = uid,
+            Role = role,
+            Forename1 = forename1,
+            Forename2 = forename2,
+            Surname = surname,
+            DateOfAppointment = startDate?.ToString("dd/MM/yyyy"),
+            DateTermOfOfficeEndsEnded = endDate?.ToString("dd/MM/yyyy"),
+            AppointingBody = appointingBody
+        };
+
+        var governor = new Governor(
+            gid,
+            uid,
+            fullName,
+            role,
+            appointingBody,
+            startDate,
+            endDate,
+            null
+        );
+
+        var tadTrustGovernance = new TadTrustGovernance
+        {
+            Gid = gid
+        };
+
+        _mockAcademiesDbContext.GiasGovernances.Add(giasGovernance);
+        _mockAcademiesDbContext.TadTrustGovernances.Add(tadTrustGovernance);
+
+        return governor;
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -15,7 +15,6 @@ public class TrustRepositoryTests
 
     private readonly DateTime _lastYear = DateTime.Today.AddYears(-1);
     private readonly DateTime _nextYear = DateTime.Today.AddYears(1);
-    private readonly DateTime _lastDecade = DateTime.Today.AddYears(-10);
     private readonly DateTime _yesterday = DateTime.Today.AddDays(-1);
     private readonly DateTime _today = DateTime.Today;
     private readonly DateTime _tomorrow = DateTime.Today.AddDays(1);
@@ -132,101 +131,6 @@ public class TrustRepositoryTests
             "",
             new DateTime(2007, 6, 28, 0, 0, 0, DateTimeKind.Utc)
         ));
-    }
-
-    [Fact]
-    public async Task GetTrustGovernanceAsync_ShouldReturnEmpty_WithNoGovernanceSet()
-    {
-        var result = await _sut.GetTrustGovernanceAsync("1234");
-
-        result.Should().BeEquivalentTo(new TrustGovernance([], [], [], []));
-    }
-
-    [Theory]
-    [InlineData("Member")]
-    [InlineData("Trustee")]
-    [InlineData("Accounting Officer")]
-    [InlineData("Chief Financial Officer")]
-    [InlineData("Chair of Trustees")]
-    public async Task GetTrustGovernanceAsync_ShouldReturnValidGovernors_WithTheCorrectRole(string role)
-    {
-        var output = CreateGovernor("1234", "9999", _lastYear, _nextYear, role, email: null);
-
-        var result = await _sut.GetTrustGovernanceAsync("1234");
-
-        var members = new List<Governor>();
-        var trustees = new List<Governor>();
-        var trustLeadership = new List<Governor>();
-
-        switch (role)
-        {
-            case "Member":
-                members.Add(output);
-                break;
-            case "Trustee":
-                trustees.Add(output);
-                break;
-            case "Accounting Officer":
-            case "Chief Financial Officer":
-            case "Chair of Trustees":
-                trustLeadership.Add(output);
-                break;
-        }
-
-        result.Should().BeEquivalentTo(
-            new TrustGovernance(trustLeadership.ToArray(), members.ToArray(), trustees.ToArray(), [])
-        );
-    }
-
-    [Theory]
-    [InlineData("Shared Chair of Local Governing Body - Group")]
-    [InlineData("Shared Local Governor - Group")]
-    [InlineData("Governor")]
-    [InlineData("Local Govenor")]
-    public async Task GetTrustGovernanceAsync_ShouldReturnNoGovernors_WithTheIncorrectRole(string role)
-    {
-        _ = CreateGovernor("1234", "9999", _lastYear, _nextYear, role);
-        var result = await _sut.GetTrustGovernanceAsync("1234");
-
-        result.Should().BeEquivalentTo(
-            new TrustGovernance([], [], [], [])
-        );
-    }
-
-    [Theory]
-    [InlineData("Member")]
-    [InlineData("Trustee")]
-    [InlineData("Accounting Officer")]
-    [InlineData("Chief Financial Officer")]
-    [InlineData("Chair of Trustees")]
-    [InlineData("Shared Chair of Local Governing Body - Group")]
-    [InlineData("Shared Local Governor - Group")]
-    [InlineData("Governor")]
-    [InlineData("Local Govenor")]
-    public async Task GetTrustGovernanceAsync_ShouldReturnHistoricGovernors_WhenTheyExist_IrrespectiveOfRole(
-        string role)
-    {
-        var output = CreateGovernor("1234", "9999", _lastDecade, _lastYear, role, email: null);
-
-        var result = await _sut.GetTrustGovernanceAsync("1234");
-
-        result.Should().BeEquivalentTo(
-            new TrustGovernance([], [], [], [output])
-        );
-    }
-
-    [Fact]
-    public async Task GetTrustGovernanceAsync_ShouldSortHistoricAndCurrentGovernors()
-    {
-        var currentMember1 = CreateGovernor("1234", "9999", _lastDecade, _today, email: null);
-        var currentMember2 = CreateGovernor("1234", "9998", _lastDecade, _tomorrow, email: null);
-        var historicMember = CreateGovernor("1234", "9997", _lastDecade, _yesterday, email: null);
-
-        var result = await _sut.GetTrustGovernanceAsync("1234");
-
-        result.Should().BeEquivalentTo(
-            new TrustGovernance([], [currentMember1, currentMember2], [], [historicMember])
-        );
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -25,6 +25,7 @@ public class TrustServiceTests
     private readonly TrustService _sut;
     private readonly IAcademyRepository _mockAcademyRepository = Substitute.For<IAcademyRepository>();
     private readonly ITrustRepository _mockTrustRepository = Substitute.For<ITrustRepository>();
+    private readonly ITrustGovernanceRepository _mockTrustGovernanceRepository = Substitute.For<ITrustGovernanceRepository>();
     private readonly IContactRepository _mockContactRepository = Substitute.For<IContactRepository>();
     private readonly IDateTimeProvider _mockDateTimeProvider = Substitute.For<IDateTimeProvider>();
     private readonly MockMemoryCache _mockMemoryCache = new();
@@ -33,6 +34,7 @@ public class TrustServiceTests
     {
         _sut = new TrustService(_mockAcademyRepository,
             _mockTrustRepository,
+            _mockTrustGovernanceRepository,
             _mockContactRepository,
             _mockMemoryCache.Object,
             _mockDateTimeProvider);
@@ -150,8 +152,7 @@ public class TrustServiceTests
             AppointingBody: "Nick Warms",
             Email: null
         );
-        _mockTrustRepository.GetTrustGovernanceAsync("1234")
-            .Returns(Task.FromResult(new TrustGovernance([leader], [member], [trustee], [historic])));
+        _mockTrustGovernanceRepository.GetTrustGovernanceAsync("1234").Returns([leader, member, trustee, historic]);
 
         var result = await _sut.GetTrustGovernanceAsync("1234");
 


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 209158](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/209158): Build: Governance turnover percentage - update calculation and push live. Other branches for this feature should be merged into this one.

Users reported that the previous governance turnover calculation was incorrect and this feature was disabled until the problem could be addressed.

This PR modifies the calculation so that now only trustees and the Chair of Trustees are considered, and re-enables the feature flag so that this data is now visible again.

## Changes

- The `TrustRepository.GetTrustGovernanceAsync` method has been removed in favour of a simpler method on a new `TrustGovernanceRepository` that achieves the same result.
- The `TrustService.GetGovernanceTurnoverRate` method has been refactored and updated to only use governors where the role is either `"Trustee"` or `"Chair of Trustees"`.
- The `Governor` record now has the `HasRoleChairOfTrustees` property publicly exposed.
- The `_GovernanceTurnover.cshtml` partial view has been reworked to use the [inset text](https://design-system.service.gov.uk/components/inset-text/) and [details](https://design-system.service.gov.uk/components/details/) components, along with improved wording.
- The `GovernanceTurnover` feature flag has been enabled in all environments.

## Screenshots of UI changes

### Before
Governance turnover rate is not displayed:
<img width="2419" height="2109" alt="" src="https://github.com/user-attachments/assets/82d661fb-e7ff-45f9-946c-1e46e6bc5890" />

### After
Governance pages now display the turnover rate:
<img width="2419" height="2997" alt="" src="https://github.com/user-attachments/assets/34bcf377-9de2-41b6-b938-4f2451d163ea" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
