### PR TITLE
Provide complete information in Ofsted data downloads for schools

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Services/Export/ExportColumns.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/ExportColumns.cs
@@ -46,6 +46,15 @@
             InspectionType = 1,
             DateOfInspection = 2,
             Grade = 3,
+            QualityOfEducation = 4,
+            BehaviourAndAttitudes = 5,
+            PersonalDevelopment = 6,
+            LeadershipAndManagement = 7,
+            EarlyYearsProvision = 8,
+            SixthFormProvision = 9,
+            EffectiveSafeguarding = 10,
+            CategoryOfConcern = 11,
+            BeforeOrAfterJoiningTrust = 12,
         }
 
         public enum AcademyColumns

--- a/DfE.FindInformationAcademiesTrusts/Services/Export/OfstedSchoolDataExportService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/OfstedSchoolDataExportService.cs
@@ -1,6 +1,8 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Exceptions;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Extensions;
+using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.School;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -12,11 +14,22 @@ public interface IOfstedSchoolDataExportService
 
 public class OfstedSchoolDataExportService(ISchoolService schoolService, ISchoolOverviewDetailsService schoolOverviewDetailsService) : ExportBuilder("Ofsted"), IOfstedSchoolDataExportService
 {
+    private const string NotAvailable = "Not available";
+
     private readonly List<string> _headers =
     [
         "Inspection type",
         "Date of inspection",
         "Grade",
+        "Quality of education",
+        "Behaviour and attitudes",
+        "Personal development",
+        "Leadership and management",
+        "Early years provision",
+        "Sixth form provision",
+        "Effective safeguarding",
+        "Category of concern",
+        "Before or after joining the trust",
     ];
 
     public async Task<byte[]> BuildAsync(int urn)
@@ -30,40 +43,63 @@ public class OfstedSchoolDataExportService(ISchoolService schoolService, ISchool
         
         var schoolOverview =
             await schoolOverviewDetailsService.GetSchoolOverviewDetailsAsync(urn, schoolDetails.Category);
-        var headlineGrades = await schoolService.GetOfstedHeadlineGrades(urn);
+        var ofstedRatings = await schoolService.GetSchoolOfstedRatingsAsync(urn);
         return WriteSchoolInformation(schoolOverview, schoolDetails.Category)
             .WriteHeaders(_headers)
-            .WriteRows(() => WriteRows(headlineGrades))
+            .WriteRows(() => WriteRows(ofstedRatings))
             .Build();
     }
     
-    private void WriteRows(OfstedHeadlineGradesServiceModel headlineGrades)
+    private void WriteRows(SchoolOfstedServiceModel ofstedRatings)
     {
-        if (headlineGrades.HasRecentShortInspection)
+        if (ofstedRatings.HasRecentShortInspection)
         {
-            WriteRecentShortInspectionRow(headlineGrades.ShortInspection);
+            var whenDidShortInspectionHappen = ofstedRatings.DateAcademyJoinedTrust switch
+            {
+                null => BeforeOrAfterJoining.NotApplicable,
+                var d when d <= ofstedRatings.ShortInspection.InspectionDate => BeforeOrAfterJoining.After,
+                var d when d > ofstedRatings.ShortInspection.InspectionDate => BeforeOrAfterJoining.Before,
+                _ => BeforeOrAfterJoining.NotApplicable
+            };
+            WriteRecentShortInspectionRow(ofstedRatings.ShortInspection, whenDidShortInspectionHappen);
         }
-        WriteFullInspectionRow(headlineGrades.CurrentInspection, true);
-        WriteFullInspectionRow(headlineGrades.PreviousInspection, false);
+        WriteFullInspectionRow(ofstedRatings.CurrentOfstedRating, true, ofstedRatings.WhenDidCurrentInspectionHappen);
+        WriteFullInspectionRow(ofstedRatings.PreviousOfstedRating, false, ofstedRatings.WhenDidPreviousInspectionHappen);
     }
 
-    private void WriteRecentShortInspectionRow(OfstedShortInspection shortInspection)
+    private void WriteRecentShortInspectionRow(OfstedShortInspection shortInspection, BeforeOrAfterJoining beforeOrAfterJoiningTrust)
     {
-        WriteInspectionRow("Recent short inspection", shortInspection.InspectionDate, shortInspection.InspectionOutcome);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.InspectionType, "Recent short inspection");
+        SetDateCell(ExportColumns.OfstedSchoolColumns.DateOfInspection, shortInspection.InspectionDate);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.Grade, shortInspection.InspectionOutcome ?? string.Empty);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.QualityOfEducation, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.BehaviourAndAttitudes, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.PersonalDevelopment, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.LeadershipAndManagement, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.EarlyYearsProvision, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.SixthFormProvision, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.EffectiveSafeguarding, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.CategoryOfConcern, NotAvailable);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.BeforeOrAfterJoiningTrust, beforeOrAfterJoiningTrust.ToDisplayString());
+        
+        CurrentRow++;
     }
 
-    private void WriteFullInspectionRow(OfstedFullInspectionSummary fullInspection, bool isCurrent)
+    private void WriteFullInspectionRow(OfstedRating ofstedRating, bool isCurrent, BeforeOrAfterJoining beforeOrAfterJoiningTrust)
     {
-        var inspectionType = isCurrent ? "Current inspection" : "Previous inspection";
-        WriteInspectionRow(inspectionType, fullInspection.InspectionDate, fullInspection.InspectionOutcome.ToDisplayString(isCurrent));
-    }
-
-    private void WriteInspectionRow(string inspectionType, DateTime? inspectionDate, string? inspectionOutcome)
-    {
-        SetTextCell(ExportColumns.OfstedSchoolColumns.InspectionType, inspectionType);
-        SetDateCell(ExportColumns.OfstedSchoolColumns.DateOfInspection, inspectionDate);
-        SetTextCell(ExportColumns.OfstedSchoolColumns.Grade, inspectionOutcome ?? string.Empty);
-
+        SetTextCell(ExportColumns.OfstedSchoolColumns.InspectionType, isCurrent ? "Current inspection" : "Previous inspection");
+        SetDateCell(ExportColumns.OfstedSchoolColumns.DateOfInspection, ofstedRating.InspectionDate);
+        SetTextCell(ExportColumns.OfstedSchoolColumns.Grade, ofstedRating.OverallEffectiveness.ToDisplayString(isCurrent));
+        SetTextCell(ExportColumns.OfstedSchoolColumns.QualityOfEducation, ofstedRating.QualityOfEducation.ToDisplayString(isCurrent));
+        SetTextCell(ExportColumns.OfstedSchoolColumns.BehaviourAndAttitudes, ofstedRating.BehaviourAndAttitudes.ToDisplayString(isCurrent));
+        SetTextCell(ExportColumns.OfstedSchoolColumns.PersonalDevelopment, ofstedRating.PersonalDevelopment.ToDisplayString(isCurrent));
+        SetTextCell(ExportColumns.OfstedSchoolColumns.LeadershipAndManagement, ofstedRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(isCurrent));
+        SetTextCell(ExportColumns.OfstedSchoolColumns.EarlyYearsProvision, ofstedRating.EarlyYearsProvision.ToDisplayString(isCurrent));
+        SetTextCell(ExportColumns.OfstedSchoolColumns.SixthFormProvision, ofstedRating.SixthFormProvision.ToDisplayString(isCurrent));
+        SetTextCell(ExportColumns.OfstedSchoolColumns.EffectiveSafeguarding, ofstedRating.SafeguardingIsEffective.ToDisplayString());
+        SetTextCell(ExportColumns.OfstedSchoolColumns.CategoryOfConcern, ofstedRating.CategoryOfConcern.ToDisplayString());
+        SetTextCell(ExportColumns.OfstedSchoolColumns.BeforeOrAfterJoiningTrust, beforeOrAfterJoiningTrust.ToDisplayString());
+        
         CurrentRow++;
     }
 }


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 232787](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/232787): Iterate the 'download all Ofsted data' capability in school records. Other branches for this feature should be merged into this one.

Currently a downloaded spreadsheet for a school's Ofsted data only contains the single headline grades. This expands the spreadsheet to cover the full Ofsted reports for the current and previous inspections.

## Changes

- The `OfstedSchoolDataExportService` has been updated to include nine new columns:
  - Inspection type
  - Date of inspection
  - Grade
  - Quality of education
  - Behaviour and attitudes
  - Personal development
  - Leadership and management
  - Early years provision
  - Sixth form provision
  - Effective safeguarding
  - Category of concern
  - Before or after joining the trust

## Screenshots of UI changes

### Before
Spreadsheet only contains single headline grades:
<img width="851" height="250" alt="" src="https://github.com/user-attachments/assets/c8de246d-7df1-4435-804c-ed86912e24b3" />

### After
Updated spreadsheet contains single headline grades as well as the newly added columns mentioned above:
<img width="2494" height="192" alt="" src="https://github.com/user-attachments/assets/1de2c664-2c57-4571-bd7a-21289e588b1a" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
