### PR TITLE
[203479] Changed trust details from cards design to lists

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml
@@ -2,90 +2,98 @@
 @model TrustDetailsModel
 
 @{
-  Layout = "_TrustLayout";
+    Layout = "_TrustLayout";
 }
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m" data-testid="subpage-header">
-      Trust details
-    </h2>
-    <div class="govuk-summary-card" data-testid="trust-details-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <h3 class="govuk-summary-card__title">Trust details</h3>
-      </div>
-      <div class="govuk-summary-card__content">
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Address
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="address">
-              @Model.TrustOverview.Address
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Opened on
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="opened-on">
-              @if (Model.TrustOverview.OpenedDate is not null)
-              {
-                @Model.TrustOverview.OpenedDate.Value.ToString(StringFormatConstants.DisplayDateFormat)
-              }
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Region and territory
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="region-and-territory">
-              @Model.TrustOverview.RegionAndTerritory
-            </dd>
-          </div>
-          @if (Model.SharepointLink is not null)
-          {
+
+<div class="govuk-grid-row" data-testid="trust-details-summary">
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" data-testid="subpage-header">
+            @Model.PageMetadata.SubPageName
+        </h3>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+
             <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                SharePoint folder (opens in a new tab)
-              </dt>
-              <dd class="govuk-summary-list__value" data-testid="sharepoint-link">
-                <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.SharepointLink">Find this trust's SharePoint folder</a>
-              </dd>
+                <dt class="govuk-summary-list__key" data-testid="address">
+                    Address
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.TrustOverview.Address
+                </dd>
             </div>
-          }
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Information from other services (opens in a new tab)
-            </dt>
-            <dd class="govuk-summary-list__value">
-              @if (Model.CompaniesHouseLink is not null)
-              {
-                  <p class="govuk-body">
-                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.CompaniesHouseLink">Companies House</a>
-                  </p>
-              }
-              @if (Model.GetInformationAboutSchoolsLink is not null)
-              {
-                  <p class="govuk-body">
-                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.GetInformationAboutSchoolsLink">Get information about schools</a>
-                  </p>
-              }
-              @if (Model.FinancialBenchmarkingInsightsToolLink is not null)
-              {
-                  <p class="govuk-body">
-                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.FinancialBenchmarkingInsightsToolLink">Financial Benchmarking and Insights Tool</a>
-                  </p>
-              }
-              @if (Model.FindSchoolPerformanceLink is not null)
-              {
-                  <p class="govuk-body">
-                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.FindSchoolPerformanceLink">Find school college and performance data in England</a>
-                  </p>
-              }
-            </dd>
-          </div>
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key" data-testid="opened-on">
+                    Opened on
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @if (Model.TrustOverview.OpenedDate is not null)
+                    {
+                        @Model.TrustOverview.OpenedDate.Value.ToString(StringFormatConstants.DisplayDateFormat)
+                    }
+                </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key" data-testid="region-and-territory">
+                    Region and territory
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.TrustOverview.RegionAndTerritory
+                </dd>
+            </div>
+
+            @if (Model.SharepointLink is not null)
+            {
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        SharePoint folder (opens in a new tab)
+                    </dt>
+                    <dd class="govuk-summary-list__value" data-testid="sharepoint-link">
+                        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.SharepointLink">Find this trust's SharePoint folder</a>
+                    </dd>
+                </div>
+            }
         </dl>
-      </div>
+
+        <hr class="govuk-section-break govuk-section-break--m">
+        <h3 class="govuk-heading-m" data-testid="details-information-from-other-services-header">
+            Information from other
+            services
+        </h3>
+        <p class="govuk-body">Links open in a new tab</p>
+        <ul class="govuk-list govuk-list--bullet">
+
+            @if (Model.GetInformationAboutSchoolsLink is not null)
+            {
+                <li>
+                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="details-gias-link"
+                       href="@Model.GetInformationAboutSchoolsLink">
+                        Get information about schools
+                    </a>
+                </li>
+            }
+            @if (Model.FinancialBenchmarkingInsightsToolLink is not null)
+            {
+                <li>
+                    <a class="govuk-link" rel="noreferrer noopener" target="_blank"
+                       data-testid="details-financial-benchmarking-link"
+                       href="@Model.FinancialBenchmarkingInsightsToolLink">
+                        Financial benchmarking
+                    </a>
+                </li>
+            }
+            @if (Model.FindSchoolPerformanceLink is not null)
+            {
+                <li>
+                    <a class="govuk-link" rel="noreferrer noopener" target="_blank"
+                       data-testid="details-find-school-performance-link" href="@Model.FindSchoolPerformanceLink">
+                        Find school college and performance data
+                    </a>
+                </li>
+            }
+        </ul>
+
+        <hr class="govuk-section-break govuk-section-break--m">
     </div>
-  </div>
 </div>

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
@@ -15,8 +15,9 @@ describe("Testing the components of the Trust overview page", () => {
 
             overviewPage
                 .checkTrustDetailsSubHeaderPresent()
-                .checkTrustDetailsCardPresent()
-                .checkTrustDetailsCardItemsPresent();
+                .checkTrustDetailsPresent()
+                .checkTrustDetailsItemsPresent()
+                .checkInformationFromOtherServicesPresent();
 
             navigation
                 .checkPageNameBreadcrumbPresent("Overview");
@@ -75,7 +76,7 @@ describe("Testing the components of the Trust overview page", () => {
 
             overviewPage
                 .checkAllSubNavItemsPresent()
-                .checkTrustDetailsCardPresent();
+                .checkTrustDetailsPresent();
         });
 
         it('Should check that the trust summary navigation button takes me to the correct page', () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/overviewPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/overviewPage.ts
@@ -7,10 +7,13 @@ class OverviewPage {
         tableRowSortValues: () => cy.get('tbody.govuk-table__body tr td[data-sort-value]'),
         firstRowRatingText: () => cy.get('tbody.govuk-table__body tr:first-child td:first-child'),
         detailsHeader: () => cy.get('[data-testid="page-name"]'),
-        trustDetailsCard: () => cy.get('[data-testid="trust-details-summary-card"]'),
+        trustDetails: () => cy.get('[data-testid="trust-details-summary"]'),
         referenceNumberCard: () => cy.get('[data-testid="reference-numbers-summary-card"]'),
         trustDetailsSubHeader: () => cy.get('[data-testid="reference-numbers-summary-card"]'),
-
+        informationForOtherServicesHeader: () => cy.get('[data-testid="details-information-from-other-services-header"]'),
+        giasLink: () => cy.get('[data-testid="details-gias-link"]'),
+        financialBenchmarkingLink: () => cy.get('[data-testid="details-financial-benchmarking-link"]'),
+        findSchoolPerformanceDataLink: () => cy.get('[data-testid="details-find-school-performance-link"]'),
         subNav: {
             trustDetailsSubnavButton: () => cy.get('[data-testid="overview-trust-details-subnav"]'),
             trustSummarySubnavButton: () => cy.get('[data-testid="overview-trust-summary-subnav"]'),
@@ -41,17 +44,23 @@ class OverviewPage {
         return this;
     }
 
-    public checkTrustDetailsCardPresent(): this {
-        this.elements.trustDetailsCard().should('be.visible');
-        this.elements.trustDetailsCard().should('contain', 'Trust details');
+    public checkTrustDetailsPresent(): this {
+        this.elements.trustDetails().should('be.visible');
+        this.elements.trustDetails().should('contain', 'Trust details');
         return this;
     }
 
-    public checkTrustDetailsCardItemsPresent(): this {
-        this.elements.trustDetailsCard().should('contain', 'Address');
-        this.elements.trustDetailsCard().should('contain', 'Opened on');
-        this.elements.trustDetailsCard().should('contain', 'Region and territory');
-        this.elements.trustDetailsCard().should('contain', 'Information from other services');
+    public checkTrustDetailsItemsPresent(): this {
+        this.elements.trustDetails().should('contain', 'Address');
+        this.elements.trustDetails().should('contain', 'Opened on');
+        this.elements.trustDetails().should('contain', 'Region and territory');
+        return this;
+    }
+
+    public checkInformationFromOtherServicesPresent(): this {
+        this.elements.giasLink().should('be.visible').and('contain.text', 'Get information about schools');
+        this.elements.financialBenchmarkingLink().should('be.visible').and('contain.text', 'Financial benchmarking');
+        this.elements.findSchoolPerformanceDataLink().should('be.visible').and('contain.text', 'Find school college and performance data');
         return this;
     }
 


### PR DESCRIPTION
This pull requests changes the design of the trust overview page to align with the tables (summary list component) on other pages.

[User Story 203479](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/203479): Tech debt: Cards to lists - Trust details

## Changes

HTML changes to use the summery list designs

## Screenshots of UI changes

### Before

<img width="857" height="740" alt="image" src="https://github.com/user-attachments/assets/03034072-ee2a-49f9-9b87-914be4a86642" />

### After
<img width="870" height="835" alt="image" src="https://github.com/user-attachments/assets/3e1b5712-baed-4288-82d0-3a7cab876de3" />


## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
