### PR TITLE
[203479] Changed trust reference number and summary from cards designs to lists

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml
@@ -5,7 +5,7 @@
     Layout = "_TrustLayout";
 }
 
-<div class="govuk-grid-row" data-testid="trust-reference-numbers">
+<div class="govuk-grid-row" data-testid="reference-numbers">
     <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m" data-testid="subpage-header">
             @Model.PageMetadata.SubPageName

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml
@@ -2,53 +2,55 @@
 @model ReferenceNumbersModel
 
 @{
-  Layout = "_TrustLayout";
+    Layout = "_TrustLayout";
 }
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m" data-testid="subpage-header">
-      Reference numbers
-    </h2>
-    <div class="govuk-summary-card" data-testid="reference-numbers-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <h3 class="govuk-summary-card__title">Reference numbers</h3>
-      </div>
-      <div class="govuk-summary-card__content">
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              UID (Unique group identifier)
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="trust-uid">
-              @Model.TrustOverview.Uid
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              Group ID (identifier) and TRN (trust reference number)
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="trust-reference-number">
-              @Model.TrustOverview.GroupId
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              UKPRN (UK provider reference number)
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="ukprn">
-              @Model.TrustOverview.Ukprn
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              Companies House number
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="companies-house-number">
-              @Model.TrustOverview.CompaniesHouseNumber
-            </dd>
-          </div>
+
+<div class="govuk-grid-row" data-testid="trust-reference-numbers">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m" data-testid="subpage-header">
+            @Model.PageMetadata.SubPageName
+        </h2>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    UID (Unique group identifier)
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="trust-uid">
+                    @Model.TrustOverview.Uid
+                </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    Group ID (identifier) and TRN (trust reference number)
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="trust-reference-number">
+                    @Model.TrustOverview.GroupId
+                </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    UKPRN (UK provider reference number)
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="ukprn">
+                    @Model.TrustOverview.Ukprn
+                </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    Companies House number
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="companies-house-number">
+                    @Model.TrustOverview.CompaniesHouseNumber
+                </dd>
+            </div>
+
         </dl>
-      </div>
+
+        <hr class="govuk-section-break govuk-section-break--m">
     </div>
-  </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml
@@ -2,65 +2,66 @@
 @model TrustSummaryModel
 
 @{
-  Layout = "_TrustLayout";
+    Layout = "_TrustLayout";
 }
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m" data-testid="subpage-header">
-      Trust summary
-    </h2>
-    <div class="govuk-summary-card" data-testid="trust-summary">
-      <div class="govuk-summary-card__title-wrapper">
-        <h3 class="govuk-summary-card__title" id="trust-information">Trust summary</h3>
-      </div>
-      <div class="govuk-summary-card__content">
-        <dl class="govuk-summary-list">
-          <!-- Total Academies -->
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              Total academies
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="total-academies">
-              @Model.TrustOverview.TotalAcademies
-            </dd>
-          </div>
-          <!-- Academies in Each Local Authority -->
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              Academies in each local authority
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="academies-in-each-authority">
-              @foreach (var (authority, total) in Model.AcademiesInEachLocalAuthority)
-              {
-                <p class="govuk-body govuk-!-margin-bottom-1">@total in @authority</p>
-              }
-            </dd>
-          </div>
-          <!-- Pupil Numbers -->
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              Pupil numbers
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="number-of-pupils">
-              @($"{Model.TrustOverview.TotalPupilNumbers:n0}")
-            </dd>
-          </div>
-          <!-- Pupil Capacity and Percentage Full -->
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-half">
-              Pupil capacity <br>(% full)
-            </dt>
-            <dd class="govuk-summary-list__value" data-testid="pupil-capacity">
-              @($"{Model.TrustOverview.TotalCapacity:n0}")
-              @if (Model.TrustOverview.PercentageFull is not null)
-              {
-                <br>
-                @($"({Model.TrustOverview.PercentageFull}%)")
-              }
-            </dd>
-          </div>
+
+<div class="govuk-grid-row" data-testid="trust-summary">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m" data-testid="subpage-header">
+            @Model.PageMetadata.SubPageName
+        </h2>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    Total academies
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="total-academies">
+                    @Model.TrustOverview.TotalAcademies
+                </dd>
+            </div>
+
+            <!-- Academies in Each Local Authority -->
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    Academies in each local authority
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="academies-in-each-authority">
+                    @foreach (var (authority, total) in Model.AcademiesInEachLocalAuthority)
+                    {
+                        <p class="govuk-body govuk-!-margin-bottom-1">@total in @authority</p>
+                    }
+                </dd>
+            </div>
+
+            <!-- Pupil Numbers -->
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    Pupil numbers
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="number-of-pupils">
+                    @($"{Model.TrustOverview.TotalPupilNumbers:n0}")
+                </dd>
+            </div>
+
+            <!-- Pupil Capacity and Percentage Full -->
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                    Pupil capacity <br>(% full)
+                </dt>
+                <dd class="govuk-summary-list__value" data-testid="pupil-capacity">
+                    @($"{Model.TrustOverview.TotalCapacity:n0}")
+                    @if (Model.TrustOverview.PercentageFull is not null)
+                    {
+                        <br>
+                        @($"({Model.TrustOverview.PercentageFull}%)")
+                    }
+                </dd>
+            </div>
+
         </dl>
-      </div>
+
+        <hr class="govuk-section-break govuk-section-break--m">
     </div>
-  </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml
@@ -14,7 +14,7 @@
         <dl class="govuk-summary-list govuk-!-margin-bottom-0">
 
             <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                <dt class="govuk-summary-list__key">
                     Total academies
                 </dt>
                 <dd class="govuk-summary-list__value" data-testid="total-academies">
@@ -24,7 +24,7 @@
 
             <!-- Academies in Each Local Authority -->
             <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                <dt class="govuk-summary-list__key">
                     Academies in each local authority
                 </dt>
                 <dd class="govuk-summary-list__value" data-testid="academies-in-each-authority">
@@ -37,7 +37,7 @@
 
             <!-- Pupil Numbers -->
             <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+                <dt class="govuk-summary-list__key">
                     Pupil numbers
                 </dt>
                 <dd class="govuk-summary-list__value" data-testid="number-of-pupils">
@@ -47,14 +47,13 @@
 
             <!-- Pupil Capacity and Percentage Full -->
             <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
-                    Pupil capacity <br>(% full)
+                <dt class="govuk-summary-list__key">
+                    Pupil capacity (% full)
                 </dt>
                 <dd class="govuk-summary-list__value" data-testid="pupil-capacity">
                     @($"{Model.TrustOverview.TotalCapacity:n0}")
                     @if (Model.TrustOverview.PercentageFull is not null)
                     {
-                        <br>
                         @($"({Model.TrustOverview.PercentageFull}%)")
                     }
                 </dd>

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
@@ -36,8 +36,8 @@ describe("Testing the components of the Trust overview page", () => {
             overviewPage
                 .checkTrustSummarySubHeaderPresent()
                 .checkOverviewHeaderPresent()
-                .checkTrustSummaryCardPresent()
-                .checkTrustSummaryCardItemsPresent();
+                .checkTrustSummaryDetailsPresent()
+                .checkTrustSummaryItemsPresent();
 
             navigation
                 .checkPageNameBreadcrumbPresent("Overview");
@@ -55,8 +55,8 @@ describe("Testing the components of the Trust overview page", () => {
 
             overviewPage
                 .checkReferenceNumbersSubHeaderPresent()
-                .checkReferenceNumbersCardPresent()
-                .checkReferenceNumbersCardItemsPresent();
+                .checkReferenceNumbersSectionPresent()
+                .checkReferenceNumbersItemsPresent();
 
             navigation
                 .checkPageNameBreadcrumbPresent("Overview");
@@ -90,7 +90,7 @@ describe("Testing the components of the Trust overview page", () => {
 
             overviewPage
                 .checkAllSubNavItemsPresent()
-                .checkTrustSummaryCardPresent();
+                .checkTrustSummaryDetailsPresent();
         });
 
         it('Should check that the reference numbers navigation button takes me to the correct page', () => {
@@ -104,7 +104,7 @@ describe("Testing the components of the Trust overview page", () => {
 
             overviewPage
                 .checkAllSubNavItemsPresent()
-                .checkReferenceNumbersCardPresent();
+                .checkReferenceNumbersSectionPresent();
         });
 
         it('Should check that the overview sub nav items are not present when I am not on the overview page', () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/overviewPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/overviewPage.ts
@@ -2,13 +2,13 @@ class OverviewPage {
 
     elements = {
         overviewHeader: () => cy.get('[data-testid="page-name"]'),
-        trustSummaryCard: () => cy.get('[data-testid="trust-summary"]'),
+        trustSummary: () => cy.get('[data-testid="trust-summary"]'),
         overviewOfstedSummaryCardContentBox: () => cy.get('[data-testid="ofsted-ratings"]'),
         tableRowSortValues: () => cy.get('tbody.govuk-table__body tr td[data-sort-value]'),
         firstRowRatingText: () => cy.get('tbody.govuk-table__body tr:first-child td:first-child'),
         detailsHeader: () => cy.get('[data-testid="page-name"]'),
         trustDetails: () => cy.get('[data-testid="trust-details-summary"]'),
-        referenceNumberCard: () => cy.get('[data-testid="reference-numbers-summary-card"]'),
+        referenceNumbers: () => cy.get('[data-testid="reference-numbers"]'),
         trustDetailsSubHeader: () => cy.get('[data-testid="reference-numbers-summary-card"]'),
         informationForOtherServicesHeader: () => cy.get('[data-testid="details-information-from-other-services-header"]'),
         giasLink: () => cy.get('[data-testid="details-gias-link"]'),
@@ -30,17 +30,17 @@ class OverviewPage {
         return this;
     }
 
-    public checkTrustSummaryCardItemsPresent(): this {
-        this.elements.trustSummaryCard().should('contain', 'Total academies');
-        this.elements.trustSummaryCard().should('contain', 'Academies in each local authority');
-        this.elements.trustSummaryCard().should('contain', 'Pupil numbers');
-        this.elements.trustSummaryCard().should('contain', 'Pupil capacity');
+    public checkTrustSummaryItemsPresent(): this {
+        this.elements.trustSummary().should('contain', 'Total academies');
+        this.elements.trustSummary().should('contain', 'Academies in each local authority');
+        this.elements.trustSummary().should('contain', 'Pupil numbers');
+        this.elements.trustSummary().should('contain', 'Pupil capacity');
         return this;
     }
 
-    public checkTrustSummaryCardPresent(): this {
-        this.elements.trustSummaryCard().should('be.visible');
-        this.elements.trustSummaryCard().should('contain', 'Trust summary');
+    public checkTrustSummaryDetailsPresent(): this {
+        this.elements.trustSummary().should('be.visible');
+        this.elements.trustSummary().should('contain', 'Trust summary');
         return this;
     }
 
@@ -64,17 +64,17 @@ class OverviewPage {
         return this;
     }
 
-    public checkReferenceNumbersCardPresent(): this {
-        this.elements.referenceNumberCard().should('be.visible');
-        this.elements.referenceNumberCard().should('contain', 'Reference numbers');
+    public checkReferenceNumbersSectionPresent(): this {
+        this.elements.referenceNumbers().should('be.visible');
+        this.elements.referenceNumbers().should('contain', 'Reference numbers');
         return this;
     }
 
-    public checkReferenceNumbersCardItemsPresent(): this {
-        this.elements.referenceNumberCard().should('contain', 'UID');
-        this.elements.referenceNumberCard().should('contain', 'Group ID');
-        this.elements.referenceNumberCard().should('contain', 'UKPRN');
-        this.elements.referenceNumberCard().should('contain', 'Companies House number');
+    public checkReferenceNumbersItemsPresent(): this {
+        this.elements.referenceNumbers().should('contain', 'UID');
+        this.elements.referenceNumbers().should('contain', 'Group ID');
+        this.elements.referenceNumbers().should('contain', 'UKPRN');
+        this.elements.referenceNumbers().should('contain', 'Companies House number');
         return this;
     }
 


### PR DESCRIPTION
The pull request changes the design of both the reference numbers page and summary for the trusts. Brining the design into alignment with the rest of the application

[User Story 203474](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/203474): Tech debt: Cards to lists - Reference numbers

[User Story 203476](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/203476): Tech debt: Cards to lists - Trust summary

## Changes
- Changed the layout to use the govuk-summary-list from the govuk-summary-card 

## Screenshots of UI changes

**Trust Summary**
### Before
<img width="862" height="686" alt="image" src="https://github.com/user-attachments/assets/baea89cd-a91f-49d8-9343-4a8036974400" />


### After
<img width="851" height="592" alt="image" src="https://github.com/user-attachments/assets/e270fc5d-fb55-4c0d-be42-b434b2c3e26b" />

**Trust Reference Numbers**
### Before

<img width="860" height="695" alt="image" src="https://github.com/user-attachments/assets/ea0c921b-90b3-4695-b3a3-96432e607776" />

###After
<img width="881" height="592" alt="image" src="https://github.com/user-attachments/assets/9fee0f7b-6711-49de-8593-43e181d3185a" />


## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
