### PR TITLE
[233355] Tech debt: Alternate colour rows

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Governance/Current.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Governance/Current.cshtml
@@ -10,7 +10,7 @@
         <section class="app-table-container govuk-!-margin-bottom-9" data-testid="current-governors">
             @if (Model.SchoolGovernance.Current.Length > 0)
             {
-                <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="current-governors">
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table--school" data-module="moj-sortable-table" aria-describedby="current-governors">
                     <caption class="govuk-table__caption govuk-table__caption--m" id="current-governors" data-testid="subpage-header">Current governors</caption>
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Governance/Historic.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Governance/Historic.cshtml
@@ -10,7 +10,7 @@
         <section class="app-table-container govuk-!-margin-bottom-9" data-testid="historic-governors">
             @if (Model.SchoolGovernance.Historic.Length > 0)
             {
-                <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="historic-governors">
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table--school" data-module="moj-sortable-table" aria-describedby="historic-governors">
                     <caption class="govuk-table__caption govuk-table__caption--m" id="historic-governors" data-testid="subpage-header">Historic governors</caption>
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -58,7 +58,7 @@
                         @switch (Model.InspectionBeforeOrAfterJoiningTrust)
                         {
                             case BeforeOrAfterJoining.Before:
-                                <strong class="govuk-tag govuk-tag--grey">
+                                <strong class="govuk-tag govuk-tag--orange">
                                     Before joining
                                 </strong>
                                 break;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿﻿@page
 @using System.ComponentModel
 @using DfE.FindInformationAcademiesTrusts.Data.Enums
 @using DfE.FindInformationAcademiesTrusts.Extensions
@@ -55,7 +55,26 @@
                         Before or after joining the trust
                     </dt>
                     <dd class="govuk-summary-list__value" data-testid="before-or-after-joining-value">
-                        <partial name="_InspectionBeforeOrAfter" model="Model.InspectionBeforeOrAfterJoiningTrust" />
+                        @switch (Model.InspectionBeforeOrAfterJoiningTrust)
+                        {
+                            case BeforeOrAfterJoining.Before:
+                                <strong class="govuk-tag govuk-tag--grey">
+                                    Before joining
+                                </strong>
+                                break;
+                            case BeforeOrAfterJoining.After:
+                                <strong class="govuk-tag">
+                                    After joining
+                                </strong>
+                                break;
+                            case BeforeOrAfterJoining.NotYetInspected:
+                                <strong class="govuk-tag govuk-tag--grey">
+                                    Not yet inspected
+                                </strong>
+                                break;
+                            default:
+                                throw new InvalidEnumArgumentException($"Unknown value of BeforeOrAfterJoining: {Model.InspectionBeforeOrAfterJoiningTrust}");
+                        }
                     </dd>
                 </div>
             }
@@ -79,4 +98,3 @@
         </section>
     </div>
 </div>
-

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -55,26 +55,7 @@
                         Before or after joining the trust
                     </dt>
                     <dd class="govuk-summary-list__value" data-testid="before-or-after-joining-value">
-                        @switch (Model.InspectionBeforeOrAfterJoiningTrust)
-                        {
-                            case BeforeOrAfterJoining.Before:
-                                <strong class="govuk-tag govuk-tag--grey">
-                                    Before joining
-                                </strong>
-                                break;
-                            case BeforeOrAfterJoining.After:
-                                <strong class="govuk-tag">
-                                    After joining
-                                </strong>
-                                break;
-                            case BeforeOrAfterJoining.NotYetInspected:
-                                <strong class="govuk-tag govuk-tag--grey">
-                                    Not yet inspected
-                                </strong>
-                                break;
-                            default:
-                                throw new InvalidEnumArgumentException($"Unknown value of BeforeOrAfterJoining: {Model.InspectionBeforeOrAfterJoiningTrust}");
-                        }
+                        <partial name="_InspectionBeforeOrAfter" model="Model.InspectionBeforeOrAfterJoiningTrust" />
                     </dd>
                 </div>
             }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -55,26 +55,7 @@
                         Before or after joining the trust
                     </dt>
                     <dd class="govuk-summary-list__value" data-testid="before-or-after-joining-value">
-                        @switch (Model.InspectionBeforeOrAfterJoiningTrust)
-                        {
-                            case BeforeOrAfterJoining.Before:
-                                <strong class="govuk-tag govuk-tag--orange">
-                                    Before joining
-                                </strong>
-                                break;
-                            case BeforeOrAfterJoining.After:
-                                <strong class="govuk-tag">
-                                    After joining
-                                </strong>
-                                break;
-                            case BeforeOrAfterJoining.NotYetInspected:
-                                <strong class="govuk-tag govuk-tag--grey">
-                                    Not yet inspected
-                                </strong>
-                                break;
-                            default:
-                                throw new InvalidEnumArgumentException($"Unknown value of BeforeOrAfterJoining: {Model.InspectionBeforeOrAfterJoiningTrust}");
-                        }
+                        <partial name="_InspectionBeforeOrAfter" model="Model.InspectionBeforeOrAfterJoiningTrust" />
                     </dd>
                 </div>
             }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SafeguardingAndConcerns.cshtml
@@ -1,4 +1,4 @@
-﻿﻿@page
+﻿@page
 @using System.ComponentModel
 @using DfE.FindInformationAcademiesTrusts.Data.Enums
 @using DfE.FindInformationAcademiesTrusts.Extensions

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/SingleHeadlineGrades.cshtml
@@ -49,7 +49,7 @@
             </div>
         </details>
 
-        <table class="govuk-table govuk-!-margin-bottom-0" data-testid="ofsted-inspection-table">
+        <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table--school" data-testid="ofsted-inspection-table">
             <caption class="govuk-table__caption govuk-visually-hidden">Grades and inspection dates</caption>
 
             <thead class="govuk-table__head">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
@@ -74,7 +74,7 @@
                         @switch (Model.InspectionBeforeOrAfterJoiningTrust)
                         {
                             case BeforeOrAfterJoining.Before:
-                                <strong class="govuk-tag govuk-tag--grey">
+                                <strong class="govuk-tag govuk-tag--orange">
                                     Before joining
                                 </strong>
                                 break;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_BaseRatings.cshtml
@@ -71,26 +71,7 @@
                         Before or after joining the trust
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        @switch (Model.InspectionBeforeOrAfterJoiningTrust)
-                        {
-                            case BeforeOrAfterJoining.Before:
-                                <strong class="govuk-tag govuk-tag--orange">
-                                    Before joining
-                                </strong>
-                                break;
-                            case BeforeOrAfterJoining.After:
-                                <strong class="govuk-tag">
-                                    After joining
-                                </strong>
-                                break;
-                            case BeforeOrAfterJoining.NotYetInspected:
-                                <strong class="govuk-tag govuk-tag--grey">
-                                    Not yet inspected
-                                </strong>
-                                break;
-                            default:
-                                throw new InvalidEnumArgumentException($"Unknown value of BeforeOrAfterJoining: {Model.InspectionBeforeOrAfterJoiningTrust}");
-                        }
+                        <partial name="_InspectionBeforeOrAfter" model="Model.InspectionBeforeOrAfterJoiningTrust" />
                     </dd>
                 </div>
             }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_InspectionBeforeOrAfter.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Ofsted/_InspectionBeforeOrAfter.cshtml
@@ -1,0 +1,24 @@
+﻿@using System.ComponentModel
+@using DfE.FindInformationAcademiesTrusts.Data.Enums
+@model BeforeOrAfterJoining
+
+@switch (Model)
+{
+    case BeforeOrAfterJoining.Before:
+        <strong class="govuk-tag govuk-tag--orange">
+            Before joining
+        </strong>
+        break;
+    case BeforeOrAfterJoining.After:
+        <strong class="govuk-tag">
+            After joining
+        </strong>
+        break;
+    case BeforeOrAfterJoining.NotYetInspected:
+        <strong class="govuk-tag govuk-tag--grey">
+            Not yet inspected
+        </strong>
+        break;
+    default:
+        throw new InvalidEnumArgumentException($"Unknown value of BeforeOrAfterJoining: {Model}");
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
@@ -6,7 +6,7 @@
 }
 
 <section class="app-table-container">
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="details-caption">
+    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="details-caption">
     <caption class="govuk-table__caption govuk-table__caption--m" id="details-caption" data-testid="subpage-header">
       Details
     </caption>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml
@@ -6,7 +6,7 @@
 }
 
 <section class="app-table-container">
-    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="free-school-meals-caption">
+    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="free-school-meals-caption">
         <caption class="govuk-table__caption govuk-table__caption--m" id="free-school-meals-caption" data-testid="subpage-header">Free school meals</caption>
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml
@@ -8,7 +8,7 @@
 }
 
 <section class="app-table-container">
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="pupil-numbers-caption">
+    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="pupil-numbers-caption">
     <caption class="govuk-table__caption govuk-table__caption--m" id="pupil-numbers-caption"
              data-testid="subpage-header">Pupil numbers
     </caption>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
@@ -15,7 +15,7 @@
     }
     else
     {
-        <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="free-schools-caption">
+        <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="free-schools-caption">
             <caption class="govuk-table__caption govuk-table__caption--m" id="free-schools-caption"
                      data-testid="subpage-header">Free schools
             </caption>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml
@@ -15,7 +15,7 @@
     }
     else
     {
-        <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="post-advisory-caption">
+        <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="post-advisory-caption">
             <caption class="govuk-table__caption govuk-table__caption--m" id="post-advisory-caption"
                      data-testid="subpage-header">Post advisory board
             </caption>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml
@@ -15,7 +15,7 @@
     }
     else
     {
-        <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="pre-advisory-caption">
+        <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="pre-advisory-caption">
             <caption class="govuk-table__caption govuk-table__caption--m" id="pre-advisory-caption"
                      data-testid="subpage-header">Pre advisory board
             </caption>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml
@@ -15,7 +15,7 @@
     <section class="app-table-container govuk-!-margin-bottom-9" data-testid="historic-members">
       @if (Model.TrustGovernance.HistoricMembers.Length > 0)
       {
-        <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="historic-members">
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="historic-members">
           <caption class="govuk-table__caption govuk-table__caption--m" id="historic-members" data-testid="subpage-header">Historic members</caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml
@@ -3,58 +3,58 @@
 @model HistoricMembersModel
 
 @{
-  Layout = "_TrustLayout";
+    Layout = "_TrustLayout";
 }
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <partial name="_GovernanceTurnover" model="@Model"/>
-  </div>
+    <div class="govuk-grid-column-two-thirds">
+        <partial name="_GovernanceTurnover" model="@Model" />
+    </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <section class="app-table-container govuk-!-margin-bottom-9" data-testid="historic-members">
-      @if (Model.TrustGovernance.HistoricMembers.Length > 0)
-      {
-                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="historic-members">
-          <caption class="govuk-table__caption govuk-table__caption--m" id="historic-members" data-testid="subpage-header">Historic members</caption>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
-              <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
-              <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
-              <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
-              <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            @foreach (var governor in Model.TrustGovernance.HistoricMembers)
+    <div class="govuk-grid-column-full">
+        <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container" data-testid="historic-members">
+            @if (Model.TrustGovernance.HistoricMembers.Length > 0)
             {
-              <tr class="govuk-table__row" data-testid="historic-members-row">
-                <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="historic-members-name">
-                  @governor.FullName
-                </th>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="historic-members-role">
-                  @governor.Role
-                </td>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="historic-members-appointed">
-                  @governor.AppointingBody
-                </td>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="historic-members-from">
-                  @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
-                </td>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="historic-members-to">
-                  @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
-                </td>
-              </tr>
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="historic-members">
+                    <caption class="govuk-table__caption govuk-table__caption--m" id="historic-members" data-testid="subpage-header">Historic members</caption>
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+                            <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
+                            <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+                            <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
+                            <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        @foreach (var governor in Model.TrustGovernance.HistoricMembers)
+                        {
+                            <tr class="govuk-table__row" data-testid="historic-members-row">
+                                <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="historic-members-name">
+                                    @governor.FullName
+                                </th>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="historic-members-role">
+                                    @governor.Role
+                                </td>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="historic-members-appointed">
+                                    @governor.AppointingBody
+                                </td>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="historic-members-from">
+                                    @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
+                                </td>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="historic-members-to">
+                                    @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
             }
-          </tbody>
-        </table>
-      }
-      else
-      {
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Historic members</h3>
-        <p class="govuk-body govuk-!-margin-bottom-0">No Historic members</p>
-      }
-    </section>
-  </div>
+            else
+            {
+                <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Historic members</h3>
+                <p class="govuk-body govuk-!-margin-bottom-0">No Historic members</p>
+            }
+        </section>
+    </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml
@@ -3,54 +3,54 @@
 @model MembersModel
 
 @{
-  Layout = "_TrustLayout";
+    Layout = "_TrustLayout";
 }
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <partial name="_GovernanceTurnover" model="@Model"/>
-  </div>
+    <div class="govuk-grid-column-two-thirds">
+        <partial name="_GovernanceTurnover" model="@Model" />
+    </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <section class="govuk-!-margin-bottom-9 app-table-container" data-testid="members">
-      @if (Model.TrustGovernance.CurrentMembers.Length > 0)
-      {
-                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="members">
-          <caption class="govuk-table__caption govuk-table__caption--m" id="members" data-testid="subpage-header">Members</caption>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
-              <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
-              <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
-              <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            @foreach (var governor in Model.TrustGovernance.CurrentMembers)
+    <div class="govuk-grid-column-full">
+        <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container" data-testid="members">
+            @if (Model.TrustGovernance.CurrentMembers.Length > 0)
             {
-              <tr class="govuk-table__row" data-testid="members-row">
-                <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="members-name">
-                  @governor.FullName
-                </th>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="members-appointed">
-                  @governor.AppointingBody
-                </td>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="members-from">
-                  @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
-                </td>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="members-to">
-                  @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
-                </td>
-              </tr>
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="members">
+                    <caption class="govuk-table__caption govuk-table__caption--m" id="members" data-testid="subpage-header">Members</caption>
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+                            <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+                            <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
+                            <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        @foreach (var governor in Model.TrustGovernance.CurrentMembers)
+                        {
+                            <tr class="govuk-table__row" data-testid="members-row">
+                                <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="members-name">
+                                    @governor.FullName
+                                </th>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="members-appointed">
+                                    @governor.AppointingBody
+                                </td>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="members-from">
+                                    @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
+                                </td>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="members-to">
+                                    @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
             }
-          </tbody>
-        </table>
-      }
-      else
-      {
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Members</h3>
-        <p class="govuk-body govuk-!-margin-bottom-0">No Members</p>
-      }
-    </section>
-  </div>
+            else
+            {
+                <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Members</h3>
+                <p class="govuk-body govuk-!-margin-bottom-0">No Members</p>
+            }
+        </section>
+    </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml
@@ -15,7 +15,7 @@
     <section class="govuk-!-margin-bottom-9 app-table-container" data-testid="members">
       @if (Model.TrustGovernance.CurrentMembers.Length > 0)
       {
-        <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="members">
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="members">
           <caption class="govuk-table__caption govuk-table__caption--m" id="members" data-testid="subpage-header">Members</caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml
@@ -15,7 +15,7 @@
     <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container" data-testid="trust-leadership">
       @if (Model.TrustGovernance.CurrentTrustLeadership.Length > 0)
       {
-        <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
           <caption class="govuk-table__caption govuk-table__caption--m" id="trust-leadership" data-testid="subpage-header">Trust Leadership</caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml
@@ -15,7 +15,7 @@
     <section class="govuk-!-margin-bottom-9 app-table-container" data-testid="trustees">
       @if (Model.TrustGovernance.CurrentTrustees.Length > 0)
       {
-        <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="trustees">
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="trustees">
           <caption class="govuk-table__caption govuk-table__caption--m" id="trustees" data-testid="subpage-header">Trustees</caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml
@@ -3,54 +3,54 @@
 @model TrusteesModel
 
 @{
-  Layout = "_TrustLayout";
+    Layout = "_TrustLayout";
 }
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <partial name="_GovernanceTurnover" model="@Model"/>
-  </div>
+    <div class="govuk-grid-column-two-thirds">
+        <partial name="_GovernanceTurnover" model="@Model" />
+    </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <section class="govuk-!-margin-bottom-9 app-table-container" data-testid="trustees">
-      @if (Model.TrustGovernance.CurrentTrustees.Length > 0)
-      {
-                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="trustees">
-          <caption class="govuk-table__caption govuk-table__caption--m" id="trustees" data-testid="subpage-header">Trustees</caption>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
-              <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
-              <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
-              <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            @foreach (var governor in Model.TrustGovernance.CurrentTrustees)
+    <div class="govuk-grid-column-full">
+        <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container" data-testid="trustees">
+            @if (Model.TrustGovernance.CurrentTrustees.Length > 0)
             {
-              <tr class="govuk-table__row" data-testid="trustees-row">
-                <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="trustees-name">
-                  @governor.FullName
-                </th>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="trustees-appointed">
-                  @governor.AppointingBody
-                </td>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="trustees-from">
-                  @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
-                </td>
-                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="trustees-to">
-                  @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
-                </td>
-              </tr>
+                <table class="govuk-table govuk-!-margin-bottom-0 si-row-colours-table" data-module="moj-sortable-table" aria-describedby="trustees">
+                    <caption class="govuk-table__caption govuk-table__caption--m" id="trustees" data-testid="subpage-header">Trustees</caption>
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+                            <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+                            <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
+                            <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
+                        </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                        @foreach (var governor in Model.TrustGovernance.CurrentTrustees)
+                        {
+                            <tr class="govuk-table__row" data-testid="trustees-row">
+                                <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="trustees-name">
+                                    @governor.FullName
+                                </th>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="trustees-appointed">
+                                    @governor.AppointingBody
+                                </td>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="trustees-from">
+                                    @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
+                                </td>
+                                <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortableDateFormat)" data-testid="trustees-to">
+                                    @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
             }
-          </tbody>
-        </table>
-      }
-      else
-      {
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Trustees</h3>
-        <p class="govuk-body govuk-!-margin-bottom-0">No Trustees</p>
-      }
-    </section>
-  </div>
+            else
+            {
+                <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Trustees</h3>
+                <p class="govuk-body govuk-!-margin-bottom-0">No Trustees</p>
+            }
+        </section>
+    </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml
@@ -3,70 +3,70 @@
 @model CurrentRatingsModel
 
 @{
-  Layout = "Ofsted/_OfstedLayout";
+    Layout = "Ofsted/_OfstedLayout";
 }
 
 <section class="app-table-container" data-testid="ofsted-current-ratings-table">
     <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table">
-    <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Current ratings</caption>
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header govuk-body" aria-sort="ascending" data-testid="ofsted-current-ratings-school-name-header">
-          School name
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-current-ratings-quality-of-education-header">
-          Quality of education
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-current-ratings-behaviour-and-attitudes-header">
-          Behaviour and attitudes
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-current-ratings-personal-development-header">
-          Personal development
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-current-ratings-leadership-and-management-header">
-          Leadership and management
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-current-ratings-early-years-provision-header">
-          Early years provision
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-current-ratings-sixth-form-provision-header">
-          Sixth form provision
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body" aria-sort="none" data-testid="ofsted-current-ratings-before-or-after-joining-header">
-          Before or after joining
-        </th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      @foreach (var academy in Model.Academies)
-      {
-        <tr class="govuk-table__row" data-testid="academy-row">
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.EstablishmentName" data-testid="ofsted-current-ratings-school-name">
-            @academy.EstablishmentName<br/>
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.QualityOfEducation.ToDataSortValue()" data-testid="ofsted-current-ratings-quality-of-education">
-            @academy.CurrentOfstedRating.QualityOfEducation.ToDisplayString(true)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.BehaviourAndAttitudes.ToDataSortValue()" data-testid="ofsted-current-ratings-behaviour-and-attitudes">
-            @academy.CurrentOfstedRating.BehaviourAndAttitudes.ToDisplayString(true)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.PersonalDevelopment.ToDataSortValue()" data-testid="ofsted-current-ratings-personal-development">
-            @academy.CurrentOfstedRating.PersonalDevelopment.ToDisplayString(true)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.EffectivenessOfLeadershipAndManagement.ToDataSortValue()" data-testid="ofsted-current-ratings-leadership-and-management">
-            @academy.CurrentOfstedRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(true)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.EarlyYearsProvision.ToDataSortValue()" data-testid="ofsted-current-ratings-early-years-provision">
-            @academy.CurrentOfstedRating.EarlyYearsProvision.ToDisplayString(true)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.SixthFormProvision.ToDataSortValue()" data-testid="ofsted-current-ratings-sixth-form-provision">
-            @academy.CurrentOfstedRating.SixthFormProvision.ToDisplayString(true)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.WhenDidCurrentInspectionHappen" data-testid="ofsted-current-ratings-before-or-after-joining">
-            <partial name="_BeforeOrAfterTag" model="new BeforeOrAfterTagModel(academy.WhenDidCurrentInspectionHappen, true)"/>
-          </td>
-        </tr>
-      }
-    </tbody>
-  </table>
+        <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Current ratings</caption>
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header column-header-ofsted-school-name" aria-sort="ascending" data-testid="ofsted-current-ratings-school-name-header">
+                    School name
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-current-ratings-quality-of-education-header">
+                    Quality of education
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-current-ratings-behaviour-and-attitudes-header">
+                    Behaviour and attitudes
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-current-ratings-personal-development-header">
+                    Personal development
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-current-ratings-leadership-and-management-header">
+                    Leadership and management
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-current-ratings-early-years-provision-header">
+                    Early years provision
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-current-ratings-sixth-form-provision-header">
+                    Sixth form provision
+                </th>
+                <th scope="col" class="govuk-table__header column-header-before-after" aria-sort="none" data-testid="ofsted-current-ratings-before-or-after-joining-header">
+                    Before or after joining
+                </th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            @foreach (var academy in Model.Academies)
+            {
+                <tr class="govuk-table__row" data-testid="academy-row">
+                    <td class="govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="ofsted-current-ratings-school-name">
+                        @academy.EstablishmentName<br />
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.QualityOfEducation.ToDataSortValue()" data-testid="ofsted-current-ratings-quality-of-education">
+                        @academy.CurrentOfstedRating.QualityOfEducation.ToDisplayString(true)
+                    </td>
+                    <td class="govuk-table__cell data-sort-value="@academy.CurrentOfstedRating.BehaviourAndAttitudes.ToDataSortValue()" data-testid="ofsted-current-ratings-behaviour-and-attitudes">
+                        @academy.CurrentOfstedRating.BehaviourAndAttitudes.ToDisplayString(true)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.PersonalDevelopment.ToDataSortValue()" data-testid="ofsted-current-ratings-personal-development">
+                        @academy.CurrentOfstedRating.PersonalDevelopment.ToDisplayString(true)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.EffectivenessOfLeadershipAndManagement.ToDataSortValue()" data-testid="ofsted-current-ratings-leadership-and-management">
+                        @academy.CurrentOfstedRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(true)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.EarlyYearsProvision.ToDataSortValue()" data-testid="ofsted-current-ratings-early-years-provision">
+                        @academy.CurrentOfstedRating.EarlyYearsProvision.ToDisplayString(true)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.SixthFormProvision.ToDataSortValue()" data-testid="ofsted-current-ratings-sixth-form-provision">
+                        @academy.CurrentOfstedRating.SixthFormProvision.ToDisplayString(true)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.WhenDidCurrentInspectionHappen" data-testid="ofsted-current-ratings-before-or-after-joining">
+                        <partial name="_BeforeOrAfterTag" model="new BeforeOrAfterTagModel(academy.WhenDidCurrentInspectionHappen, true)" />
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
 </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml
@@ -47,7 +47,7 @@
                     <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.QualityOfEducation.ToDataSortValue()" data-testid="ofsted-current-ratings-quality-of-education">
                         @academy.CurrentOfstedRating.QualityOfEducation.ToDisplayString(true)
                     </td>
-                    <td class="govuk-table__cell data-sort-value="@academy.CurrentOfstedRating.BehaviourAndAttitudes.ToDataSortValue()" data-testid="ofsted-current-ratings-behaviour-and-attitudes">
+                    <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.BehaviourAndAttitudes.ToDataSortValue()" data-testid="ofsted-current-ratings-behaviour-and-attitudes">
                         @academy.CurrentOfstedRating.BehaviourAndAttitudes.ToDisplayString(true)
                     </td>
                     <td class="govuk-table__cell" data-sort-value="@academy.CurrentOfstedRating.PersonalDevelopment.ToDataSortValue()" data-testid="ofsted-current-ratings-personal-development">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml
@@ -7,7 +7,7 @@
 }
 
 <section class="app-table-container" data-testid="ofsted-current-ratings-table">
-  <table class="govuk-table" data-module="moj-sortable-table">
+    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table">
     <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Current ratings</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml
@@ -3,70 +3,70 @@
 @model PreviousRatingsModel
 
 @{
-  Layout = "Ofsted/_OfstedLayout";
+    Layout = "Ofsted/_OfstedLayout";
 }
 
 <section class="app-table-container" data-testid="ofsted-previous-ratings-table">
     <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table">
-    <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Previous ratings</caption>
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header govuk-body" aria-sort="ascending" data-testid="ofsted-previous-ratings-school-name-header">
-          School name
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-previous-ratings-quality-of-education-header">
-          Quality of education
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-previous-ratings-behaviour-and-attitudes-header">
-          Behaviour and attitudes
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-previous-ratings-personal-development-header">
-          Personal development
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-previous-ratings-leadership-and-management-header">
-          Leadership and management
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-previous-ratings-early-years-provision-header">
-          Early years provision
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-rating" aria-sort="none" data-testid="ofsted-previous-ratings-sixth-form-provision-header">
-          Sixth form provision
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body" aria-sort="none" data-testid="ofsted-previous-ratings-before-or-after-joining-header">
-          Before or after joining
-        </th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      @foreach (var academy in Model.Academies)
-      {
-        <tr class="govuk-table__row" data-testid="academy-row">
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.EstablishmentName" data-testid="ofsted-previous-ratings-school-name">
-            @academy.EstablishmentName<br/>
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.PreviousOfstedRating.QualityOfEducation.ToDataSortValue()" data-testid="ofsted-previous-ratings-quality-of-education">
-            @academy.PreviousOfstedRating.QualityOfEducation.ToDisplayString(false)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.PreviousOfstedRating.BehaviourAndAttitudes.ToDataSortValue()" data-testid="ofsted-previous-ratings-behaviour-and-attitudes">
-            @academy.PreviousOfstedRating.BehaviourAndAttitudes.ToDisplayString(false)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.PreviousOfstedRating.PersonalDevelopment.ToDataSortValue()" data-testid="ofsted-previous-ratings-personal-development">
-            @academy.PreviousOfstedRating.PersonalDevelopment.ToDisplayString(false)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.PreviousOfstedRating.EffectivenessOfLeadershipAndManagement.ToDataSortValue()" data-testid="ofsted-previous-ratings-leadership-and-management">
-            @academy.PreviousOfstedRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(false)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.PreviousOfstedRating.EarlyYearsProvision.ToDataSortValue()" data-testid="ofsted-previous-ratings-early-years-provision">
-            @academy.PreviousOfstedRating.EarlyYearsProvision.ToDisplayString(false)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.PreviousOfstedRating.SixthFormProvision.ToDataSortValue()" data-testid="ofsted-previous-ratings-sixth-form-provision">
-            @academy.PreviousOfstedRating.SixthFormProvision.ToDisplayString(false)
-          </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.WhenDidPreviousInspectionHappen" data-testid="ofsted-previous-ratings-before-or-after-joining">
-            <partial name="_BeforeOrAfterTag" model="new BeforeOrAfterTagModel(academy.WhenDidPreviousInspectionHappen, false)"/>
-          </td>
-        </tr>
-      }
-    </tbody>
-  </table>
+        <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Previous ratings</caption>
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header column-header-ofsted-school-name" aria-sort="ascending" data-testid="ofsted-previous-ratings-school-name-header">
+                    School name
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-previous-ratings-quality-of-education-header">
+                    Quality of education
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-previous-ratings-behaviour-and-attitudes-header">
+                    Behaviour and attitudes
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-previous-ratings-personal-development-header">
+                    Personal development
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-previous-ratings-leadership-and-management-header">
+                    Leadership and management
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-previous-ratings-early-years-provision-header">
+                    Early years provision
+                </th>
+                <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-previous-ratings-sixth-form-provision-header">
+                    Sixth form provision
+                </th>
+                <th scope="col" class="govuk-table__header column-header-before-after" aria-sort="none" data-testid="ofsted-previous-ratings-before-or-after-joining-header">
+                    Before or after joining
+                </th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            @foreach (var academy in Model.Academies)
+            {
+                <tr class="govuk-table__row" data-testid="academy-row">
+                    <td class="govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="ofsted-previous-ratings-school-name">
+                        @academy.EstablishmentName<br />
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.PreviousOfstedRating.QualityOfEducation.ToDataSortValue()" data-testid="ofsted-previous-ratings-quality-of-education">
+                        @academy.PreviousOfstedRating.QualityOfEducation.ToDisplayString(false)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.PreviousOfstedRating.BehaviourAndAttitudes.ToDataSortValue()" data-testid="ofsted-previous-ratings-behaviour-and-attitudes">
+                        @academy.PreviousOfstedRating.BehaviourAndAttitudes.ToDisplayString(false)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.PreviousOfstedRating.PersonalDevelopment.ToDataSortValue()" data-testid="ofsted-previous-ratings-personal-development">
+                        @academy.PreviousOfstedRating.PersonalDevelopment.ToDisplayString(false)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.PreviousOfstedRating.EffectivenessOfLeadershipAndManagement.ToDataSortValue()" data-testid="ofsted-previous-ratings-leadership-and-management">
+                        @academy.PreviousOfstedRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(false)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.PreviousOfstedRating.EarlyYearsProvision.ToDataSortValue()" data-testid="ofsted-previous-ratings-early-years-provision">
+                        @academy.PreviousOfstedRating.EarlyYearsProvision.ToDisplayString(false)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.PreviousOfstedRating.SixthFormProvision.ToDataSortValue()" data-testid="ofsted-previous-ratings-sixth-form-provision">
+                        @academy.PreviousOfstedRating.SixthFormProvision.ToDisplayString(false)
+                    </td>
+                    <td class="govuk-table__cell" data-sort-value="@academy.WhenDidPreviousInspectionHappen" data-testid="ofsted-previous-ratings-before-or-after-joining">
+                        <partial name="_BeforeOrAfterTag" model="new BeforeOrAfterTagModel(academy.WhenDidPreviousInspectionHappen, false)" />
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
 </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml
@@ -7,7 +7,7 @@
 }
 
 <section class="app-table-container" data-testid="ofsted-previous-ratings-table">
-  <table class="govuk-table" data-module="moj-sortable-table">
+    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table">
     <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Previous ratings</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
@@ -23,7 +23,7 @@
     </div>
   </details>
   <hr class="govuk-section-break govuk-section-break--m">
-  <table class="govuk-table" data-module="moj-sortable-table">
+    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table">
     <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Safeguarding and concerns</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
@@ -42,7 +42,7 @@
     </div>
   </details>
   <hr class="govuk-section-break govuk-section-break--m">
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="ofsted-caption">
+    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="ofsted-caption">
     <caption id="ofsted-caption" class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Single headline grades</caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
@@ -42,7 +42,7 @@
     </div>
   </details>
   <hr class="govuk-section-break govuk-section-break--m">
-    <table class="govuk-table si-row-colours-table" data-module="moj-sortable-table" aria-describedby="ofsted-caption">
+    <table class="govuk-table si-row-colours-table trust-single-headline-grades" data-module="moj-sortable-table" aria-describedby="ofsted-caption">
     <caption id="ofsted-caption" class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Single headline grades</caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
@@ -46,30 +46,30 @@
     <caption id="ofsted-caption" class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Single headline grades</caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-body" aria-sort="ascending"
+      <th scope="col" class="govuk-table__header" aria-sort="ascending"
           data-testid="ofsted-single-headline-grades-school-name-header">
         School name
       </th>
-      <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none"
+      <th scope="col" class="govuk-table__header table-col--13" aria-sort="none"
           data-testid="ofsted-single-headline-grades-date-joined-header">
         Date joined
       </th>
-      <th scope="col" class="govuk-table__header govuk-body" aria-sort="none" data-testid="ofsted-single-headline-grades-has-recent-short-inspection">
+      <th scope="col" class="govuk-table__header" aria-sort="none" data-testid="ofsted-single-headline-grades-has-recent-short-inspection">
         Has recent short inspection
       </th>
-      <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-single-headline-grade" aria-sort="none"
+      <th scope="col" class="govuk-table__header" aria-sort="none"
           data-testid="ofsted-single-headline-grades-current-single-headline-grade-header">
         Current single headline grade
       </th>
-      <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none"
+      <th scope="col" class="govuk-table__header table-col--13" aria-sort="none"
           data-testid="ofsted-single-headline-grades-date-of-current-inspection-header">
         Date of current inspection
       </th>
-      <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-single-headline-grade" aria-sort="none"
+      <th scope="col" class="govuk-table__header" aria-sort="none"
           data-testid="ofsted-single-headline-grades-previous-single-headline-grade-header">
         Previous single headline grade
       </th>
-      <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none"
+       <th scope="col" class="govuk-table__header table-col--13" aria-sort="none"
           data-testid="ofsted-single-headline-grades-date-of-previous-inspection-header">
         Date of previous inspection
       </th>
@@ -79,13 +79,13 @@
     @foreach (var academy in Model.Academies)
     {
       <tr class="govuk-table__row" data-testid="academy-row">
-        <td class="govuk-table__cell govuk-body" data-sort-value="@academy.EstablishmentName" data-testid="ofsted-single-headline-grades-school-name">
+        <td class="govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="ofsted-single-headline-grades-school-name">
           <partial name="Trusts/_AcademyLink" model="@(new AcademyLinkModel(academy.EstablishmentName, "/Schools/Ofsted/SingleHeadlineGrades", academy.Urn))" />
         </td>
-        <td class="govuk-table__cell govuk-body" data-sort-value="@academy.DateAcademyJoinedTrust!.Value.ToString(StringFormatConstants.SortableDateFormat)" data-testid="ofsted-single-headline-grades-date-joined">
+        <td class="govuk-table__cell" data-sort-value="@academy.DateAcademyJoinedTrust!.Value.ToString(StringFormatConstants.SortableDateFormat)" data-testid="ofsted-single-headline-grades-date-joined">
           @academy.DateAcademyJoinedTrust!.Value.ToString(StringFormatConstants.DisplayDateFormat)
         </td>
-        <td class="govuk-table__cell govuk-body" data-sort-value="@academy.HasRecentShortInspection" data-testid="ofsted-single-headline-grades-has-recent-short-inspection">
+        <td class="govuk-table__cell" data-sort-value="@academy.HasRecentShortInspection" data-testid="ofsted-single-headline-grades-has-recent-short-inspection">
           @(academy.HasRecentShortInspection ? "Yes" : "No")
         </td>
         <partial name="_SingleHeadlineGradeCells" model="new SingleHeadlineGradeCellsModel(academy.CurrentOfstedRating, academy.WhenDidCurrentInspectionHappen, true)"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/_BeforeOrAfterTag.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/_BeforeOrAfterTag.cshtml
@@ -14,7 +14,7 @@
   }
   case BeforeOrAfterJoining.Before:
   {
-    <strong class="govuk-tag govuk-tag--grey govuk-!-text-align-centre govuk-!-width-three-quarters">
+    <strong class="govuk-tag govuk-tag--orange govuk-!-text-align-centre govuk-!-width-three-quarters">
       Before
     </strong>
     break;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/_SingleHeadlineGradeCells.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/_SingleHeadlineGradeCells.cshtml
@@ -1,15 +1,15 @@
 @model SingleHeadlineGradeCellsModel
 
 @* Single headline grade *@
-<td class="govuk-table__cell govuk-body cell-ofsted-single-headline-grade"
+<td class="govuk-table__cell cell-ofsted-single-headline-grade"
   data-sort-value="@Model.SingleHeadlineGradeSort">
   <span class=@(Model.RatingShouldBeBold ? "govuk-!-font-weight-bold" : null)
     data-testid="@Model.DataTestIdPrefix-single-headline-grade">
     @Model.SingleHeadlineGradeText
   </span>
   @if (Model.HasInspection)
-  {
-    <strong class="govuk-tag @(Model.IsBeforeJoining ? "govuk-tag--orange" : "") govuk-!-text-align-centre govuk-!-width-three-quarters"
+  { 
+      <strong class="govuk-tag @(Model.IsBeforeJoining ? "govuk-tag--orange" : "") govuk-!-margin-top-1"
       data-testid="@Model.DataTestIdPrefix-before-after-joining">
       @Model.TagLabel
     </strong>
@@ -17,7 +17,7 @@
 </td>
 
 @* Inspection date *@
-<td class="govuk-table__cell govuk-body" data-sort-value="@Model.InspectionDateSort"
+<td class="govuk-table__cell" data-sort-value="@Model.InspectionDateSort"
   data-testid="@Model.DataTestIdPrefix-date-of-inspection">
   @Model.InspectionDateText
 </td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/_SingleHeadlineGradeCells.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/_SingleHeadlineGradeCells.cshtml
@@ -9,8 +9,7 @@
   </span>
   @if (Model.HasInspection)
   {
-    <strong
-      class="govuk-tag @(Model.IsBeforeJoining ? "govuk-tag--grey" : "") govuk-!-text-align-centre govuk-!-width-three-quarters"
+    <strong class="govuk-tag @(Model.IsBeforeJoining ? "govuk-tag--orange" : "") govuk-!-text-align-centre govuk-!-width-three-quarters"
       data-testid="@Model.DataTestIdPrefix-before-after-joining">
       @Model.TagLabel
     </strong>

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -1,72 +1,66 @@
 .app-table-container {
-  overflow: auto;
+    overflow: auto;
 
-  [aria-sort] button {
-    // increase padding slightly to add space between the column header and the sort icon
-    // as we have removed the negative position below
-    padding-right: 1rem;
-    // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
-    &::before {
-      top: 11px;
+    [aria-sort] button {
+        // increase padding slightly to add space between the column header and the sort icon
+        // as we have removed the negative position below
+        padding-right: 1rem;
+        // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
+        &::before {
+            top: 11px;
+        }
+        // Fix sort icons causing content to always overflow container
+        // this causes horizontal scroll to always visible when using overflow:auto
+        &::before,
+        &::after {
+            right: 0;
+        }
     }
-    // Fix sort icons causing content to always overflow container
-    // this causes horizontal scroll to always visible when using overflow:auto
-    &::before,
-    &::after {
-      right: 0;
+
+    .column-header-date {
+        width: 13%;
     }
-  }
 
-  .column-header-ofsted-rating {
-    width: 10%;
-  }
-
-  .column-header-date {
-    width: 13%;
-  }
-
-  .column-header-ofsted-single-headline-grade {
-    width: 16%;
-  }
-
-  .column-header-ofsted-concern {
-    width: 18%;
-  }
-
-  .cell-ofsted-single-headline-grade {
-    .govuk-tag {
-      margin-top: 10px;
-      margin-bottom: 7px;
+    .column-header-ofsted-school-name {
+        width: 17%;
     }
-  }
 
-  .table-col--13 {
-    width: 13%;
-  }
-
-  .si-row-colours-table {
-    .govuk-table__head {
-      background: #ebf2f6;
+    .column-header-ofsted-concern {
+        width: 18%;
     }
-  }
 
-  .si-row-colours-table--school {
-    .govuk-table__head {
-      background-color: #edeaf4;
+    .cell-ofsted-single-headline-grade {
+        .govuk-tag {
+            margin-top: 10px;
+            margin-bottom: 7px;
+        }
     }
-  }
 
-  .si-row-colours-table,
-  .si-row-colours-table--school {
-    .govuk-table__row:nth-child(even) {
-      background: #f6f6f6;
+    .table-col--13 {
+        width: 13%;
     }
-  }
 
-  .trust-single-headline-grades {
+    .si-row-colours-table {
+        .govuk-table__head {
+            background: #ebf2f6;
+        }
+    }
+
+    .si-row-colours-table--school {
+        .govuk-table__head {
+            background-color: #edeaf4;
+        }
+    }
+
+    .si-row-colours-table,
+    .si-row-colours-table--school {
+        .govuk-table__row:nth-child(even) {
+            background: #f6f6f6;
+        }
+    }
+
     .govuk-table__cell,
     .govuk-table__header {
-      padding: 15px;
+        padding: 15px;
     }
-  }
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -63,8 +63,10 @@
     }
   }
 
-  .govuk-table__header,
-  .govuk-table__cell {
-    padding: 15px;
+  .trust-single-headline-grades {
+    .govuk-table__cell,
+    .govuk-table__header {
+      padding: 15px;
+    }
   }
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -1,66 +1,66 @@
 .app-table-container {
-    overflow: auto;
+  overflow: auto;
 
-    [aria-sort] button {
-        // increase padding slightly to add space between the column header and the sort icon
-        // as we have removed the negative position below
-        padding-right: 1rem;
-        // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
-        &::before {
-            top: 11px;
-        }
-        // Fix sort icons causing content to always overflow container
-        // this causes horizontal scroll to always visible when using overflow:auto
-        &::before,
-        &::after {
-            right: 0;
-        }
+  [aria-sort] button {
+    // increase padding slightly to add space between the column header and the sort icon
+    // as we have removed the negative position below
+    padding-right: 1rem;
+    // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
+    &::before {
+      top: 11px;
     }
+    // Fix sort icons causing content to always overflow container
+    // this causes horizontal scroll to always visible when using overflow:auto
+    &::before,
+    &::after {
+      right: 0;
+    }
+  }
 
-    .column-header-date {
-        width: 13%;
-    }
+  .column-header-date {
+    width: 13%;
+  }
 
-    .column-header-ofsted-school-name {
-        width: 17%;
-    }
+  .column-header-ofsted-school-name {
+    width: 17%;
+  }
 
-    .column-header-ofsted-concern {
-        width: 18%;
-    }
+  .column-header-ofsted-concern {
+    width: 18%;
+  }
 
-    .cell-ofsted-single-headline-grade {
-        .govuk-tag {
-            margin-top: 10px;
-            margin-bottom: 7px;
-        }
+  .cell-ofsted-single-headline-grade {
+    .govuk-tag {
+      margin-top: 10px;
+      margin-bottom: 7px;
     }
+  }
 
-    .table-col--13 {
-        width: 13%;
-    }
+  .table-col--13 {
+    width: 13%;
+  }
 
-    .si-row-colours-table {
-        .govuk-table__head {
-            background: #ebf2f6;
-        }
+  .si-row-colours-table {
+    .govuk-table__head {
+      background: #ebf2f6;
     }
+  }
 
-    .si-row-colours-table--school {
-        .govuk-table__head {
-            background-color: #edeaf4;
-        }
+  .si-row-colours-table--school {
+    .govuk-table__head {
+      background-color: #edeaf4;
     }
+  }
 
-    .si-row-colours-table,
-    .si-row-colours-table--school {
-        .govuk-table__row:nth-child(even) {
-            background: #f6f6f6;
-        }
+  .si-row-colours-table,
+  .si-row-colours-table--school {
+    .govuk-table__row:nth-child(even) {
+      background: #f6f6f6;
     }
+  }
 
-    .govuk-table__cell,
-    .govuk-table__header {
-        padding: 15px;
-    }
+  .govuk-table__cell,
+  .govuk-table__header {
+    padding: 15px;
+  }
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -40,6 +40,10 @@
     }
   }
 
+  .table-col--13 {
+    width: 13%;
+  }
+
   .si-row-colours-table {
     .govuk-table__head {
       background: #ebf2f6;
@@ -57,5 +61,10 @@
     .govuk-table__row:nth-child(even) {
       background: #f6f6f6;
     }
+  }
+
+  .govuk-table__header,
+  .govuk-table__cell {
+    padding: 15px;
   }
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -53,8 +53,7 @@
     }
 
     .si-row-colours-table, .si-row-colours-table--school {
-
-        tr.govuk-table__row:nth-child(even) {
+        .govuk-table__row:nth-child(even) {
             background: #f6f6f6;
         }
     }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -1,44 +1,61 @@
 .app-table-container {
-  overflow: auto;
+    overflow: auto;
 
-  [aria-sort] button {
-    // increase padding slightly to add space between the column header and the sort icon
-    // as we have removed the negative position below
-    padding-right: 1rem;
-
-    // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
-    &::before {
-      top: 11px;
+    [aria-sort] button {
+        // increase padding slightly to add space between the column header and the sort icon
+        // as we have removed the negative position below
+        padding-right: 1rem;
+        // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
+        &::before {
+            top: 11px;
+        }
+        // Fix sort icons causing content to always overflow container
+        // this causes horizontal scroll to always visible when using overflow:auto
+        &::before,
+        &::after {
+            right: 0;
+        }
     }
 
-    // Fix sort icons causing content to always overflow container
-    // this causes horizontal scroll to always visible when using overflow:auto
-    &::before,
-    &::after {
-      right: 0;
+    .column-header-ofsted-rating {
+        width: 10%;
     }
-  }
 
-  .column-header-ofsted-rating {
-    width: 10%;
-  }
-
-  .column-header-date {
-    width: 13%;
-  }
-
-  .column-header-ofsted-single-headline-grade {
-    width: 16%;
-  }
-
-  .column-header-ofsted-concern {
-    width: 18%;
-  }
-
-  .cell-ofsted-single-headline-grade {
-    .govuk-tag {
-      margin-top: 10px;
-      margin-bottom: 7px;
+    .column-header-date {
+        width: 13%;
     }
-  }
+
+    .column-header-ofsted-single-headline-grade {
+        width: 16%;
+    }
+
+    .column-header-ofsted-concern {
+        width: 18%;
+    }
+
+    .cell-ofsted-single-headline-grade {
+        .govuk-tag {
+            margin-top: 10px;
+            margin-bottom: 7px;
+        }
+    }
+
+    .si-row-colours-table {
+        .govuk-table__head {
+            background: #ebf2f6;
+        }
+    }
+
+    .si-row-colours-table--school {
+        .govuk-table__head {
+            background-color: #edeaf4;
+        }
+    }
+
+    .si-row-colours-table, .si-row-colours-table--school {
+
+        tr.govuk-table__row:nth-child(even) {
+            background: #f6f6f6;
+        }
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -1,60 +1,61 @@
 .app-table-container {
-    overflow: auto;
+  overflow: auto;
 
-    [aria-sort] button {
-        // increase padding slightly to add space between the column header and the sort icon
-        // as we have removed the negative position below
-        padding-right: 1rem;
-        // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
-        &::before {
-            top: 11px;
-        }
-        // Fix sort icons causing content to always overflow container
-        // this causes horizontal scroll to always visible when using overflow:auto
-        &::before,
-        &::after {
-            right: 0;
-        }
+  [aria-sort] button {
+    // increase padding slightly to add space between the column header and the sort icon
+    // as we have removed the negative position below
+    padding-right: 1rem;
+    // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
+    &::before {
+      top: 11px;
     }
+    // Fix sort icons causing content to always overflow container
+    // this causes horizontal scroll to always visible when using overflow:auto
+    &::before,
+    &::after {
+      right: 0;
+    }
+  }
 
-    .column-header-ofsted-rating {
-        width: 10%;
-    }
+  .column-header-ofsted-rating {
+    width: 10%;
+  }
 
-    .column-header-date {
-        width: 13%;
-    }
+  .column-header-date {
+    width: 13%;
+  }
 
-    .column-header-ofsted-single-headline-grade {
-        width: 16%;
-    }
+  .column-header-ofsted-single-headline-grade {
+    width: 16%;
+  }
 
-    .column-header-ofsted-concern {
-        width: 18%;
-    }
+  .column-header-ofsted-concern {
+    width: 18%;
+  }
 
-    .cell-ofsted-single-headline-grade {
-        .govuk-tag {
-            margin-top: 10px;
-            margin-bottom: 7px;
-        }
+  .cell-ofsted-single-headline-grade {
+    .govuk-tag {
+      margin-top: 10px;
+      margin-bottom: 7px;
     }
+  }
 
-    .si-row-colours-table {
-        .govuk-table__head {
-            background: #ebf2f6;
-        }
+  .si-row-colours-table {
+    .govuk-table__head {
+      background: #ebf2f6;
     }
+  }
 
-    .si-row-colours-table--school {
-        .govuk-table__head {
-            background-color: #edeaf4;
-        }
+  .si-row-colours-table--school {
+    .govuk-table__head {
+      background-color: #edeaf4;
     }
+  }
 
-    .si-row-colours-table, .si-row-colours-table--school {
-        .govuk-table__row:nth-child(even) {
-            background: #f6f6f6;
-        }
+  .si-row-colours-table,
+  .si-row-colours-table--school {
+    .govuk-table__row:nth-child(even) {
+      background: #f6f6f6;
     }
+  }
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -268,6 +268,7 @@ class OfstedPage {
         this.elements.currentRatings.personalDevelopmentHeader().should('be.visible');
         this.elements.currentRatings.leadershipAndManagementHeader().should('be.visible');
         this.elements.currentRatings.earlyYearsProvisionHeader().should('be.visible');
+        this.elements.currentRatings.sixthFormProvisionHeader().scrollIntoView();
         this.elements.currentRatings.sixthFormProvisionHeader().should('be.visible');
         this.elements.currentRatings.beforeOrAfterJoiningHeader().scrollIntoView();
         this.elements.currentRatings.beforeOrAfterJoiningHeader().should('be.visible');
@@ -365,6 +366,7 @@ class OfstedPage {
         this.elements.previousRatings.personalDevelopmentHeader().should('be.visible');
         this.elements.previousRatings.leadershipAndManagementHeader().should('be.visible');
         this.elements.previousRatings.earlyYearsProvisionHeader().should('be.visible');
+        this.elements.previousRatings.sixthFormProvisionHeader().scrollIntoView();
         this.elements.previousRatings.sixthFormProvisionHeader().should('be.visible');
         this.elements.previousRatings.beforeOrAfterJoiningHeader().scrollIntoView();
         this.elements.previousRatings.beforeOrAfterJoiningHeader().should('be.visible');

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/test-data-store.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/test-data-store.ts
@@ -264,8 +264,8 @@ export const senSchoolData = [
 export const schoolsWithGovernanceData = [
     {
         typeOfSchool: "community school with governance data",
-        urn: 100099,
-        description: "Abbey Wood Nursery School - Local authority nursery school with current and historic governors"
+        urn: 107188,
+        description: "Abbey Green Nursery School - Local authority nursery school with current and historic governors"
     },
     {
         typeOfSchool: "academy with governance data",


### PR DESCRIPTION
This pull request adds alternate row colours to tables as well as header colour depending if the table is in a trust or school page. Due to 



[User Story 233355](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/233355): Tech debt: Alternate colour rows

## Changes

- Alternate grey shading on even rows
- Used the same light blue as is used in the hero section for Trust records, purple for School
- Added slight padding to each table cell to give some breathing room
- Added slight margin above each tag to create space between the SHG grade and tag itself
- Change "Joined before" tag from --grey to --orange

## Screenshots of UI changes

## Single Headline Grades Trust Table
### Before

<img width="1250" height="454" alt="image" src="https://github.com/user-attachments/assets/5b2604f6-acca-4618-865b-f5b1cd01d71f" />

### After

<img width="1240" height="538" alt="image" src="https://github.com/user-attachments/assets/14a109e2-b753-4678-85ce-3b98bd3f4e4e" />

## Governors table in school
### Before

<img width="1217" height="605" alt="image" src="https://github.com/user-attachments/assets/18910144-f92b-4865-9ce7-6c7056ae1ab0" />

### After

<img width="1246" height="648" alt="image" src="https://github.com/user-attachments/assets/000b3b95-7b07-469b-8cb5-9f0008a8f145" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
