### PR TITLE
Get population data from Compare spring census

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.EdperfFiat.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.EdperfFiat.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
+
+public partial class AcademiesDbContext
+{
+    public DbSet<EdperfFiat> EdperfFiats { get; set; }
+    
+    [ExcludeFromCodeCoverage]
+    protected static void OnModelCreatingEdperfFiats(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<EdperfFiat>(entity =>
+        {
+            entity.HasNoKey().ToTable("edperf_fiat", "edperf_mstr");
+            entity.Property(e => e.Urn).HasColumnName("URN");
+            entity.Property(e => e.DownloadYear).HasColumnName("DownloadYear");
+            entity.Property(e => e.CensusNor).HasColumnName("census_NOR");
+            entity.Property(e => e.CensusTsenelse).HasColumnName("census_TSENELSE");
+            entity.Property(e => e.CensusPsenelse).HasColumnName("census_PSENELSE");
+            entity.Property(e => e.CensusTsenelk).HasColumnName("census_TSENELK");
+            entity.Property(e => e.CensusPsenelk).HasColumnName("census_PSENELK");
+            entity.Property(e => e.CensusNumeal).HasColumnName("census_NUMEAL");
+            entity.Property(e => e.CensusPnumeal).HasColumnName("census_PNUMEAL");
+            entity.Property(e => e.CensusNumfsm).HasColumnName("census_NUMFSM");
+            entity.Property(e => e.AbsencePerctot).HasColumnName("absence_PERCTOT");
+            entity.Property(e => e.AbsencePpersabs10).HasColumnName("absence_PPERSABS10");
+            entity.Property(e => e.MetaCensusIngestionDatetime).HasColumnName("meta_census_ingestion_datetime");
+            entity.Property(e => e.MetaAbsenceIngestionDatetime).HasColumnName("meta_absence_ingestion_datetime");
+        });
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis_Mstr;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
@@ -32,6 +33,7 @@ public interface IAcademiesDbContext
 
     DbSet<TadHeadTeacherContact> TadHeadTeacherContacts { get; }
     DbSet<TadTrustGovernance> TadTrustGovernances { get; }
+    DbSet<EdperfFiat> EdperfFiats { get; }
 }
 
 [ExcludeFromCodeCoverage]
@@ -68,5 +70,7 @@ public partial class AcademiesDbContext : DbContext, IAcademiesDbContext
 
         OnModelCreatingTadHeadTeacherContacts(modelBuilder);
         OnModelCreatingTadTrustGovernances(modelBuilder);
+        
+        OnModelCreatingEdperfFiats(modelBuilder);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Edperf_Mstr/EdperfFiat.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Edperf_Mstr/EdperfFiat.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
+
+[ExcludeFromCodeCoverage(Justification = "Database model POCO")]
+public class EdperfFiat
+{
+    public required int Urn { get; set; }
+    public required string DownloadYear { get; set; }
+    public string? CensusNor { get; set; }
+    public string? CensusTsenelse { get; set; }
+    public string? CensusPsenelse { get; set; }
+    public string? CensusTsenelk { get; set; }
+    public string? CensusPsenelk { get; set; }
+    public string? CensusNumeal { get; set; }
+    public string? CensusPnumeal { get; set; }
+    public string? CensusNumfsm { get; set; }
+    public string? AbsencePerctot { get; set; }
+    public string? AbsencePpersabs10 { get; set; }
+    public DateTime? MetaCensusIngestionDatetime { get; set; }
+    public DateTime? MetaAbsenceIngestionDatetime { get; set; }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/PupilCensusRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/PupilCensusRepository.cs
@@ -1,0 +1,72 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+
+public class PupilCensusRepository(IAcademiesDbContext dbContext) : IPupilCensusRepository
+{
+    public async Task<AnnualStatistics<SchoolPopulation>> GetSchoolPopulationStatisticsAsync(int urn)
+    {
+        var results = await dbContext
+            .EdperfFiats
+            .Where(edperfFiat => edperfFiat.Urn == urn)
+            .ToListAsync();
+
+        var annualStatistics = new AnnualStatistics<SchoolPopulation>();
+
+        foreach (var result in results)
+        {
+            // The year is stored in the database in the format '2021-2022'.
+            // The academic year starts in the autumn, but the census is produced in the spring,
+            // so the second of the two years should be used.
+            CensusYear year = int.Parse(result.DownloadYear.Split('-')[1]);
+            
+            var pupilsOnRole = ParseIntStatistic(result.CensusNor);
+            var pupilsEligibleForFreeSchoolMeals = ParseIntStatistic(result.CensusNumfsm);
+            var pupilsEligibleForFreeSchoolMealsPercentage = pupilsEligibleForFreeSchoolMeals.Compute(
+                pupilsOnRole,
+                (fsm, por) => Math.Round(100.0m * fsm / por, 1)
+            );
+
+            var statistics = new SchoolPopulation(
+                pupilsOnRole,
+                ParseIntStatistic(result.CensusTsenelse),
+                ParseDecimalStatistic(result.CensusPsenelse),
+                ParseIntStatistic(result.CensusTsenelk),
+                ParseDecimalStatistic(result.CensusPsenelk),
+                ParseIntStatistic(result.CensusNumeal),
+                ParseDecimalStatistic(result.CensusPnumeal),
+                pupilsEligibleForFreeSchoolMeals,
+                pupilsEligibleForFreeSchoolMealsPercentage
+            );
+            
+            annualStatistics.Add(year, statistics);
+        }
+        
+        return annualStatistics;
+    }
+
+    private static Statistic<int> ParseIntStatistic(string? input) =>
+        input switch
+        {
+            "SUPP" => Statistic<int>.Suppressed,
+            "NP" => Statistic<int>.NotPublished,
+            "NA" => Statistic<int>.NotApplicable,
+            _ when int.TryParse(input, out var value) => new Statistic<int>.WithValue(value),
+            _ => Statistic<int>.NotAvailable
+        };
+
+    private static Statistic<decimal> ParseDecimalStatistic(string? input) =>
+        input switch
+        {
+            null => Statistic<decimal>.NotAvailable,
+            "SUPP" => Statistic<decimal>.Suppressed,
+            "NP" => Statistic<decimal>.NotPublished,
+            "NA" => Statistic<decimal>.NotApplicable,
+            _ when input.EndsWith('%') => ParseDecimalStatistic(input[..^1]),
+            _ when decimal.TryParse(input, out var value) => new Statistic<decimal>.WithValue(value),
+            _ => Statistic<decimal>.NotAvailable
+        };
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/AnnualStatistics.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/AnnualStatistics.cs
@@ -1,0 +1,3 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+public class AnnualStatistics<T> : Dictionary<CensusYear, T>;

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/CensusYear.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/CensusYear.cs
@@ -1,0 +1,36 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+public record CensusYear(int Value)
+{
+    private const int SpringCensusAvailabilityDeadlineMonth = 10;
+    private const int SpringCensusAvailabilityDeadlineDay = 31;
+    
+    public static implicit operator CensusYear(int year) => new(year);
+
+    public static CensusYear Current(IDateTimeProvider provider)
+    {
+        var today = provider.Today;
+        var currentYearsSpringCensusAvailabilityDeadline = new DateTime(
+            today.Year,
+            SpringCensusAvailabilityDeadlineMonth,
+            SpringCensusAvailabilityDeadlineDay,
+            0,
+            0,
+            0,
+            DateTimeKind.Utc
+        );
+
+        var censusYear = today.Year;
+        if (today < currentYearsSpringCensusAvailabilityDeadline)
+        {
+            censusYear--;
+        }
+
+        return censusYear;
+    }
+
+    public static CensusYear Next(IDateTimeProvider provider, int years = 1) => Current(provider).Value + years;
+    public static CensusYear Previous(IDateTimeProvider provider, int years = 1) => Current(provider).Value - years;
+    
+    public override string ToString() => Value.ToString();
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/IPupilCensusRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/IPupilCensusRepository.cs
@@ -1,0 +1,6 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+public interface IPupilCensusRepository
+{
+    public Task<AnnualStatistics<SchoolPopulation>> GetSchoolPopulationStatisticsAsync(int urn);
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/SchoolPopulation.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/SchoolPopulation.cs
@@ -1,0 +1,38 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+public record SchoolPopulation(
+    Statistic<int> PupilsOnRole,
+    Statistic<int> PupilsWithEhcPlan,
+    Statistic<decimal> PupilsWithEhcPlanPercentage,
+    Statistic<int> PupilsWithSenSupport,
+    Statistic<decimal> PupilsWithSenSupportPercentage,
+    Statistic<int> PupilsWithEnglishAsAdditionalLanguage,
+    Statistic<decimal> PupilsWithEnglishAsAdditionalLanguagePercentage,
+    Statistic<int> PupilsEligibleForFreeSchoolMeals,
+    Statistic<decimal> PupilsEligibleForFreeSchoolMealsPercentage
+)
+{
+    public static readonly SchoolPopulation Unknown = new(
+        Statistic<int>.NotAvailable,
+        Statistic<int>.NotAvailable,
+        Statistic<decimal>.NotAvailable,
+        Statistic<int>.NotAvailable,
+        Statistic<decimal>.NotAvailable,
+        Statistic<int>.NotAvailable,
+        Statistic<decimal>.NotAvailable,
+        Statistic<int>.NotAvailable,
+        Statistic<decimal>.NotAvailable
+    );
+
+    public static readonly SchoolPopulation NotYetSubmitted = new(
+        Statistic<int>.NotYetSubmitted,
+        Statistic<int>.NotYetSubmitted,
+        Statistic<decimal>.NotYetSubmitted,
+        Statistic<int>.NotYetSubmitted,
+        Statistic<decimal>.NotYetSubmitted,
+        Statistic<int>.NotYetSubmitted,
+        Statistic<decimal>.NotYetSubmitted,
+        Statistic<int>.NotYetSubmitted,
+        Statistic<decimal>.NotYetSubmitted
+    );
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/Statistic.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/Statistic.cs
@@ -1,0 +1,79 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+public record Statistic<T>
+{
+    public static readonly Statistic<T> Suppressed = new(StatisticKind.Suppressed);
+    public static readonly Statistic<T> NotPublished = new(StatisticKind.NotPublished);
+    public static readonly Statistic<T> NotApplicable = new(StatisticKind.NotApplicable);
+    public static readonly Statistic<T> NotAvailable = new(StatisticKind.NotAvailable);
+    public static readonly Statistic<T> NotYetSubmitted = new(StatisticKind.NotYetSubmitted);
+
+    public StatisticKind Kind { get; }
+
+    private Statistic(StatisticKind Kind)
+    {
+        this.Kind = Kind;
+    }
+
+    public virtual bool TryGetValue(out T? value)
+    {
+        value = default;
+        return false;
+    }
+
+    public static Statistic<T> FromKind(StatisticKind kind) => kind switch
+    {
+        StatisticKind.Suppressed => Suppressed,
+        StatisticKind.NotPublished => NotPublished,
+        StatisticKind.NotApplicable => NotApplicable,
+        StatisticKind.NotAvailable => NotAvailable,
+        StatisticKind.NotYetSubmitted => NotYetSubmitted,
+        StatisticKind.WithValue => throw new ArgumentException(
+            "WithValue can't be constructed without a value. Use the WithValue constructor instead of this method."
+        ),
+        _ => throw new ArgumentException($"Unknown statistic kind '{kind}'.")
+    };
+
+    public record WithValue(T Value) : Statistic<T>(StatisticKind.WithValue)
+    {
+        public override bool TryGetValue(out T? value)
+        {
+            value = Value;
+            return true;
+        }
+    }
+}
+
+public enum StatisticKind
+{
+    WithValue,
+    Suppressed,
+    NotPublished,
+    NotApplicable,
+    NotAvailable,
+    NotYetSubmitted,
+}
+
+public static class StatisticExtensions
+{
+    public static Statistic<TResult> Compute<T, TResult>(this Statistic<T> statistic, Func<T, TResult> computeFunc)
+    {
+        if (statistic is Statistic<T>.WithValue value)
+        {
+            return new Statistic<TResult>.WithValue(computeFunc(value.Value));
+        }
+
+        return Statistic<TResult>.FromKind(statistic.Kind);
+    }
+
+    public static Statistic<TResult> Compute<T1, T2, TResult>(this Statistic<T1> statistic, Statistic<T2> other,
+        Func<T1, T2, TResult> computeFunc)
+    {
+        if (statistic is Statistic<T1>.WithValue value)
+        {
+            return other.Compute(s2 => computeFunc(value.Value, s2));
+        }
+        
+        return Statistic<TResult>.FromKind(statistic.Kind);
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolPupilService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolPupilService.cs
@@ -1,0 +1,43 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.School;
+
+public interface ISchoolPupilService
+{
+    public Task<AnnualStatistics<SchoolPopulation>> GetSchoolPopulationStatisticsAsync(int urn, CensusYear from,
+        CensusYear to);
+}
+
+public class SchoolPupilService(
+    IDateTimeProvider dateTimeProvider,
+    IPupilCensusRepository pupilCensusRepository
+) : ISchoolPupilService
+{
+    public async Task<AnnualStatistics<SchoolPopulation>> GetSchoolPopulationStatisticsAsync(int urn, CensusYear from, CensusYear to)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(to.Value, from.Value);
+        Console.WriteLine(dateTimeProvider);
+        
+        var allAvailableStatistics = await pupilCensusRepository.GetSchoolPopulationStatisticsAsync(urn);
+        var result = new AnnualStatistics<SchoolPopulation>();
+
+        foreach (var year in Enumerable.Range(from.Value, to.Value - from.Value + 1))
+        {
+            if (year > CensusYear.Current(dateTimeProvider).Value)
+            {
+                result.Add(year, SchoolPopulation.NotYetSubmitted);
+            }
+            else
+            {
+                var schoolPopulation = allAvailableStatistics.TryGetValue(year, out var value)
+                    ? value
+                    : SchoolPopulation.Unknown;
+        
+                result.Add(year, schoolPopulation);
+            }
+        }
+
+        return result;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -13,6 +13,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.DataSource;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Search;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
@@ -87,6 +88,7 @@ public static class Dependencies
         builder.Services.AddScoped<IPipelineEstablishmentRepository, PipelineEstablishmentRepository>();
         builder.Services.AddScoped<ITrustDocumentRepository, TrustDocumentRepository>();
         builder.Services.AddScoped<ISchoolRepository, SchoolRepository>();
+        builder.Services.AddScoped<IPupilCensusRepository, PupilCensusRepository>();
 
         builder.Services.AddScoped<IDataSourceService, DataSourceService>();
         builder.Services.AddScoped<ITrustService, TrustService>();

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -95,6 +95,7 @@ public static class Dependencies
         builder.Services.AddScoped<IAcademyService, AcademyService>();
         builder.Services.AddScoped<IFinancialDocumentService, FinancialDocumentService>();
         builder.Services.AddScoped<ISchoolService, SchoolService>();
+        builder.Services.AddScoped<ISchoolPupilService, SchoolPupilService>();
 
         builder.Services.AddScoped<IPipelineAcademiesExportService, PipelineAcademiesExportService>();
         builder.Services.AddScoped<IOfstedTrustDataExportService, OfstedTrustDataExportService>();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis_Mstr;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
@@ -47,6 +48,9 @@ public class MockAcademiesDbContext
     //tad
     public MockDbSet<TadHeadTeacherContact> TadHeadTeacherContacts { get; } = new();
     public MockDbSet<TadTrustGovernance> TadTrustGovernances { get; } = new();
+    
+    // Pupil Census
+    public MockDbSet<EdperfFiat> EdperfFiats { get; } = new();
 
     public MockAcademiesDbContext()
     {
@@ -72,6 +76,8 @@ public class MockAcademiesDbContext
         //tad
         Object.TadHeadTeacherContacts.Returns(TadHeadTeacherContacts.Object);
         Object.TadTrustGovernances.Returns(TadTrustGovernances.Object);
+        // Pupil Census
+        Object.EdperfFiats.Returns(EdperfFiats.Object);
 
         //Set up some unused data to ensure we are actually retrieving the right data in our tests
         var otherTrust = AddGiasGroupForTrust(name: "Some other trust");
@@ -95,6 +101,8 @@ public class MockAcademiesDbContext
                 { Gid = $"{i}", Uid = otherTrust.GroupUid!, Forename1 = $"Governor {i}" });
             TadTrustGovernances.Add(new TadTrustGovernance { Gid = $"{i}", Email = $"governor{i}@othertrust.com" });
             AddMstrFreeSchoolProject(otherTrust.GroupId!);
+            
+            EdperfFiats.Add(new EdperfFiat{ Urn = i, DownloadYear = "1999-2000" });
         }
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PupilCensusRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PupilCensusRepositoryTests.cs
@@ -1,0 +1,275 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
+
+public class PupilCensusRepositoryTests
+{
+    private const int Urn = 123456;
+    
+    private readonly PupilCensusRepository _sut;
+    private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
+
+    private readonly List<EdperfFiat> _dummyEdperfFiats =
+    [
+        new()
+        {
+            Urn = Urn,
+            DownloadYear = "2020-2021",
+            CensusNor = "100",
+            CensusTsenelse = "10",
+            CensusPsenelse = "10.0",
+            CensusTsenelk = "11",
+            CensusPsenelk = "11.0",
+            CensusNumeal = "12",
+            CensusPnumeal = "12.0",
+            CensusNumfsm = "13",
+            AbsencePerctot = "14.0",
+            AbsencePpersabs10 = "15.0",
+            MetaCensusIngestionDatetime = DateTime.Parse("2020-08-31"),
+            MetaAbsenceIngestionDatetime = DateTime.Parse("2020-08-31")
+        },
+        new()
+        {
+            Urn = Urn,
+            DownloadYear = "2021-2022",
+            CensusNor = "200",
+            CensusTsenelse = "20",
+            CensusPsenelse = "20.0",
+            CensusTsenelk = "21",
+            CensusPsenelk = "21.0",
+            CensusNumeal = "22",
+            CensusPnumeal = "22.0",
+            CensusNumfsm = "23",
+            AbsencePerctot = "24.0",
+            AbsencePpersabs10 = "25.0",
+            MetaCensusIngestionDatetime = DateTime.Parse("2021-08-31"),
+            MetaAbsenceIngestionDatetime = DateTime.Parse("2021-08-31")
+        },
+        new()
+        {
+            Urn = Urn,
+            DownloadYear = "2022-2023",
+            CensusNor = "300",
+            CensusTsenelse = "30",
+            CensusPsenelse = "30.0",
+            CensusTsenelk = "31",
+            CensusPsenelk = "31.0",
+            CensusNumeal = "32",
+            CensusPnumeal = "32.0",
+            CensusNumfsm = "33",
+            AbsencePerctot = "34.0",
+            AbsencePpersabs10 = "35.0",
+            MetaCensusIngestionDatetime = DateTime.Parse("2022-08-31"),
+            MetaAbsenceIngestionDatetime = DateTime.Parse("2022-08-31")
+        },
+        new()
+        {
+            Urn = Urn,
+            DownloadYear = "2023-2024",
+            CensusNor = "400",
+            CensusTsenelse = "40",
+            CensusPsenelse = "40.0",
+            CensusTsenelk = "41",
+            CensusPsenelk = "41.0",
+            CensusNumeal = "42",
+            CensusPnumeal = "42.0",
+            CensusNumfsm = "43",
+            AbsencePerctot = "44.0",
+            AbsencePpersabs10 = "45.0",
+            MetaCensusIngestionDatetime = DateTime.Parse("2023-08-31"),
+            MetaAbsenceIngestionDatetime = DateTime.Parse("2023-08-31")
+        },
+        new()
+        {
+            Urn = Urn,
+            DownloadYear = "2024-2025",
+            CensusNor = "500",
+            CensusTsenelse = "50",
+            CensusPsenelse = "50.0",
+            CensusTsenelk = "51",
+            CensusPsenelk = "51.0",
+            CensusNumeal = "52",
+            CensusPnumeal = "52.0",
+            CensusNumfsm = "53",
+            AbsencePerctot = "54.0",
+            AbsencePpersabs10 = "55.0",
+            MetaCensusIngestionDatetime = DateTime.Parse("2024-08-31"),
+            MetaAbsenceIngestionDatetime = DateTime.Parse("2024-08-31")
+        }
+    ];
+
+    private readonly Dictionary<CensusYear, SchoolPopulation> _dummySchoolPopulations =
+        new()
+        {
+            {
+                new CensusYear(2021),
+                new SchoolPopulation(
+                    new Statistic<int>.WithValue(100),
+                    new Statistic<int>.WithValue(10),
+                    new Statistic<decimal>.WithValue(10.0m),
+                    new Statistic<int>.WithValue(11),
+                    new Statistic<decimal>.WithValue(11.0m),
+                    new Statistic<int>.WithValue(12),
+                    new Statistic<decimal>.WithValue(12.0m),
+                    new Statistic<int>.WithValue(13),
+                    new Statistic<decimal>.WithValue(13.0m)
+                )
+            },
+            {
+                new CensusYear(2022),
+                new SchoolPopulation(
+                    new Statistic<int>.WithValue(200),
+                    new Statistic<int>.WithValue(20),
+                    new Statistic<decimal>.WithValue(20.0m),
+                    new Statistic<int>.WithValue(21),
+                    new Statistic<decimal>.WithValue(21.0m),
+                    new Statistic<int>.WithValue(22),
+                    new Statistic<decimal>.WithValue(22.0m),
+                    new Statistic<int>.WithValue(23),
+                    new Statistic<decimal>.WithValue(11.5m)
+                )
+            },
+            {
+                new CensusYear(2023),
+                new SchoolPopulation(
+                    new Statistic<int>.WithValue(300),
+                    new Statistic<int>.WithValue(30),
+                    new Statistic<decimal>.WithValue(30.0m),
+                    new Statistic<int>.WithValue(31),
+                    new Statistic<decimal>.WithValue(31.0m),
+                    new Statistic<int>.WithValue(32),
+                    new Statistic<decimal>.WithValue(32.0m),
+                    new Statistic<int>.WithValue(33),
+                    new Statistic<decimal>.WithValue(11.0m)
+                )
+            },
+            {
+                new CensusYear(2024),
+                new SchoolPopulation(
+                    new Statistic<int>.WithValue(400),
+                    new Statistic<int>.WithValue(40),
+                    new Statistic<decimal>.WithValue(40.0m),
+                    new Statistic<int>.WithValue(41),
+                    new Statistic<decimal>.WithValue(41.0m),
+                    new Statistic<int>.WithValue(42),
+                    new Statistic<decimal>.WithValue(42.0m),
+                    new Statistic<int>.WithValue(43),
+                    new Statistic<decimal>.WithValue(10.8m)
+                )
+            },
+            {
+                new CensusYear(2025),
+                new SchoolPopulation(
+                    new Statistic<int>.WithValue(500),
+                    new Statistic<int>.WithValue(50),
+                    new Statistic<decimal>.WithValue(50.0m),
+                    new Statistic<int>.WithValue(51),
+                    new Statistic<decimal>.WithValue(51.0m),
+                    new Statistic<int>.WithValue(52),
+                    new Statistic<decimal>.WithValue(52.0m),
+                    new Statistic<int>.WithValue(53),
+                    new Statistic<decimal>.WithValue(10.6m)
+                )
+            }
+        };
+
+    public PupilCensusRepositoryTests()
+    {
+        _mockAcademiesDbContext.EdperfFiats.AddRange(_dummyEdperfFiats);
+
+        _sut = new PupilCensusRepository(_mockAcademiesDbContext.Object);
+    }
+
+    [Fact]
+    public async Task GetSchoolPopulationStatisticsAsync_should_return_empty_when_school_is_not_found()
+    {
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(999999);
+        
+        result.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public async Task GetSchoolPopulationStatisticsAsync_should_return_school_population_statistics_when_school_is_found()
+    {
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(Urn);
+        
+        result.Should().BeEquivalentTo(_dummySchoolPopulations);
+    }
+    
+    [Theory]
+    [InlineData("SUPP", StatisticKind.Suppressed)]
+    [InlineData("NP", StatisticKind.NotPublished)]
+    [InlineData("NA", StatisticKind.NotApplicable)]
+    [InlineData("Other text", StatisticKind.NotAvailable)]
+    [InlineData("Different text", StatisticKind.NotAvailable)]
+    [InlineData("", StatisticKind.NotAvailable)]
+    public async Task GetSchoolPopulationStatisticsAsync_parses_statistics_without_values_correctly(string statisticValue, StatisticKind expectedKind)
+    {
+        var mockDbContext = new MockAcademiesDbContext();
+        mockDbContext.EdperfFiats.AddRange([
+            new EdperfFiat
+            {
+                Urn = Urn,
+                DownloadYear = "2019-2020",
+                CensusNor = statisticValue,
+                CensusTsenelse = statisticValue,
+                CensusPsenelse = statisticValue,
+                CensusTsenelk = statisticValue,
+                CensusPsenelk = statisticValue,
+                CensusNumeal = statisticValue,
+                CensusPnumeal = statisticValue,
+                CensusNumfsm = statisticValue,
+            }
+        ]);
+
+        var sut = new PupilCensusRepository(mockDbContext.Object);
+        
+        var result = await sut.GetSchoolPopulationStatisticsAsync(Urn);
+        
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(1);
+        result[2020].PupilsOnRole.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[2020].PupilsWithEhcPlan.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[2020].PupilsWithEhcPlanPercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+        result[2020].PupilsWithSenSupport.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[2020].PupilsWithSenSupportPercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+        result[2020].PupilsWithEnglishAsAdditionalLanguage.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[2020].PupilsWithEnglishAsAdditionalLanguagePercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+        result[2020].PupilsEligibleForFreeSchoolMeals.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[2020].PupilsEligibleForFreeSchoolMealsPercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+    }
+
+    [Fact]
+    public async Task GetSchoolPopulationStatisticsAsync_parses_decimal_statistics_with_percent_signs_correctly()
+    {
+        var mockDbContext = new MockAcademiesDbContext();
+        mockDbContext.EdperfFiats.AddRange([
+            new EdperfFiat
+            {
+                Urn = Urn,
+                DownloadYear = "2019-2020",
+                CensusNor = "100",
+                CensusTsenelse = "10",
+                CensusPsenelse = "10.0%",
+                CensusTsenelk = "11",
+                CensusPsenelk = "11.0%",
+                CensusNumeal = "12",
+                CensusPnumeal = "12.0%",
+                CensusNumfsm = "13",
+            }
+        ]);
+
+        var sut = new PupilCensusRepository(mockDbContext.Object);
+        
+        var result = await sut.GetSchoolPopulationStatisticsAsync(Urn);
+        
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(1);
+        result[2020].PupilsWithEhcPlanPercentage.Should().Be(new Statistic<decimal>.WithValue(10.0m));
+        result[2020].PupilsWithSenSupportPercentage.Should().Be(new Statistic<decimal>.WithValue(11.0m));
+        result[2020].PupilsWithEnglishAsAdditionalLanguagePercentage.Should().Be(new Statistic<decimal>.WithValue(12.0m));
+        result[2020].PupilsEligibleForFreeSchoolMealsPercentage.Should().Be(new Statistic<decimal>.WithValue(13.0m));
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/AnnualStatisticsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/AnnualStatisticsTests.cs
@@ -1,0 +1,41 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
+
+public class AnnualStatisticsTests
+{
+    [Theory]
+    [InlineData(2025, 1)]
+    [InlineData(2026, 2)]
+    [InlineData(2027, 3)]
+    [InlineData(2028, 4)]
+    [InlineData(2029, 5)]
+    [InlineData(2030, 6)]
+    public void AnnualStatistics_can_use_int_as_key(int year, object expected)
+    {
+        var annualStatistics = new AnnualStatistics<object>
+        {
+            { year, expected }
+        };
+
+        annualStatistics[year].Should().Be(expected);
+    }
+    
+    [Theory]
+    [InlineData(2025, 1)]
+    [InlineData(2026, 2)]
+    [InlineData(2027, 3)]
+    [InlineData(2028, 4)]
+    [InlineData(2029, 5)]
+    [InlineData(2030, 6)]
+    public void AnnualStatistics_can_use_CensusYear_as_key(int year, object expected)
+    {
+        var censusYear = new CensusYear(year);
+        var annualStatistics = new AnnualStatistics<object>
+        {
+            { censusYear, expected }
+        };
+
+        annualStatistics[censusYear].Should().Be(expected);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/CensusYearTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/CensusYearTests.cs
@@ -1,0 +1,169 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using NSubstitute;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
+
+public class CensusYearTests
+{
+    [Theory]
+    [InlineData(2025)]
+    [InlineData(2026)]
+    [InlineData(2027)]
+    public void CensusYear_can_be_implicitly_converted_from_int(int year)
+    {
+        CensusYear censusYear = year;
+        
+        censusYear.Value.Should().Be(year);
+    }
+    
+    [Theory]
+    [InlineData(2025, 3, 15, 2024)]
+    [InlineData(2026, 1, 1, 2025)]
+    [InlineData(2027, 10, 30, 2026)]
+    public void Current_returns_previous_year_when_date_is_on_or_before_october_30th(int year, int month, int day, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Current(dateTimeProvider);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    [InlineData(2025, 10, 31, 2025)]
+    [InlineData(2026, 12, 1, 2026)]
+    [InlineData(2027, 12, 31, 2027)]
+    public void Current_returns_current_year_when_date_is_october_31st_or_later(int year, int month, int day, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Current(dateTimeProvider);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    [InlineData(2025, 3, 15, 2025)]
+    [InlineData(2026, 1, 1, 2026)]
+    [InlineData(2027, 10, 30, 2027)]
+    public void Next_returns_current_year_when_date_is_on_or_before_october_30th(int year, int month, int day, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Next(dateTimeProvider);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    [InlineData(2025, 10, 31, 2026)]
+    [InlineData(2026, 12, 1, 2027)]
+    [InlineData(2027, 12, 31, 2028)]
+    public void Next_returns_next_year_when_date_is_october_31st_or_later(int year, int month, int day, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Next(dateTimeProvider);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+    
+    [Theory]
+    [InlineData(2025, 3, 15, 1, 2025)]
+    [InlineData(2026, 1, 1, 2, 2027)]
+    [InlineData(2027, 10, 30, 3, 2029)]
+    public void Next_returns_correct_year_for_years_parameter_when_date_is_on_or_before_october_30th(int year, int month, int day, int addYears, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Next(dateTimeProvider, addYears);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    [InlineData(2025, 10, 31, 1, 2026)]
+    [InlineData(2026, 12, 1, 2, 2028)]
+    [InlineData(2027, 12, 31, 3, 2030)]
+    public void Next_returns_correct_year_for_years_parameter_when_date_is_october_31st_or_later(int year, int month, int day, int addYears, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Next(dateTimeProvider, addYears);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    [InlineData(2025, 3, 15, 2023)]
+    [InlineData(2026, 1, 1, 2024)]
+    [InlineData(2027, 10, 30, 2025)]
+    public void Previous_returns_year_before_last_when_date_is_on_or_before_october_30th(int year, int month, int day, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Previous(dateTimeProvider);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    [InlineData(2025, 10, 31, 2024)]
+    [InlineData(2026, 12, 1, 2025)]
+    [InlineData(2027, 12, 31, 2026)]
+    public void Previous_returns_previous_year_when_date_is_october_31st_or_later(int year, int month, int day, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Previous(dateTimeProvider);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+    
+    [Theory]
+    [InlineData(2025, 3, 15, 1, 2023)]
+    [InlineData(2026, 1, 1, 2, 2023)]
+    [InlineData(2027, 10, 30, 3, 2023)]
+    public void Previous_returns_correct_year_for_years_parameter_when_date_is_on_or_before_october_30th(int year, int month, int day, int subtractYears, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Previous(dateTimeProvider, subtractYears);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    [InlineData(2025, 10, 31, 1, 2024)]
+    [InlineData(2026, 12, 1, 2, 2024)]
+    [InlineData(2027, 12, 31, 3, 2024)]
+    public void Previous_returns_correct_year_for_years_parameter_when_date_is_october_31st_or_later(int year, int month, int day, int subtractYears, int expectedYear)
+    {
+        var dateTimeProvider = Substitute.For<IDateTimeProvider>();
+        dateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var censusYear = CensusYear.Previous(dateTimeProvider, subtractYears);
+
+        censusYear.Value.Should().Be(expectedYear);
+    }
+    
+    [Theory]
+    [InlineData(2025, "2025")]
+    [InlineData(2026, "2026")]
+    [InlineData(2027, "2027")]
+    public void ToString_returns_year_as_string(int year, string expected)
+    {
+        var censusYear = new CensusYear(year);
+        
+        censusYear.ToString().Should().Be(expected);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/SchoolPopulationTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/SchoolPopulationTests.cs
@@ -1,0 +1,52 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
+
+public class SchoolPopulationTests
+{
+    [Fact]
+    public void Unknown_has_NotAvailable_statistic_for_all_parameters()
+    {
+        SchoolPopulation.Unknown.PupilsOnRole
+            .Should().Be(Statistic<int>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsWithEhcPlan
+            .Should().Be(Statistic<int>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsWithEhcPlanPercentage
+            .Should().Be(Statistic<decimal>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsWithSenSupport
+            .Should().Be(Statistic<int>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsWithSenSupportPercentage
+            .Should().Be(Statistic<decimal>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsWithEnglishAsAdditionalLanguage
+            .Should().Be(Statistic<int>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsWithEnglishAsAdditionalLanguagePercentage
+            .Should().Be(Statistic<decimal>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsEligibleForFreeSchoolMeals
+            .Should().Be(Statistic<int>.NotAvailable);
+        SchoolPopulation.Unknown.PupilsEligibleForFreeSchoolMealsPercentage
+            .Should().Be(Statistic<decimal>.NotAvailable);
+    }
+
+    [Fact]
+    public void NotYetSubmitted_has_NotYetSubmitted_statistic_for_all_parameters()
+    {
+        SchoolPopulation.NotYetSubmitted.PupilsOnRole
+            .Should().Be(Statistic<int>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsWithEhcPlan
+            .Should().Be(Statistic<int>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsWithEhcPlanPercentage
+            .Should().Be(Statistic<decimal>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsWithSenSupport
+            .Should().Be(Statistic<int>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsWithSenSupportPercentage
+            .Should().Be(Statistic<decimal>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsWithEnglishAsAdditionalLanguage
+            .Should().Be(Statistic<int>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsWithEnglishAsAdditionalLanguagePercentage
+            .Should().Be(Statistic<decimal>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsEligibleForFreeSchoolMeals
+            .Should().Be(Statistic<int>.NotYetSubmitted);
+        SchoolPopulation.NotYetSubmitted.PupilsEligibleForFreeSchoolMealsPercentage
+            .Should().Be(Statistic<decimal>.NotYetSubmitted);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/StatisticExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/StatisticExtensionsTests.cs
@@ -1,0 +1,81 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
+
+public class StatisticExtensionsTests
+{
+    [Theory]
+    [InlineData(StatisticKind.Suppressed)]
+    [InlineData(StatisticKind.NotPublished)]
+    [InlineData(StatisticKind.NotApplicable)]
+    [InlineData(StatisticKind.NotAvailable)]
+    [InlineData(StatisticKind.NotYetSubmitted)]
+    public void Compute_for_one_statistic_propagates_kind_when_not_WithValue(StatisticKind kind)
+    {
+        var statistic = Statistic<int>.FromKind(kind);
+        var result = statistic.Compute(s => 2.0 * s);
+        result.Kind.Should().Be(kind);
+    }
+
+    [Theory]
+    [InlineData(1, 2.0)]
+    [InlineData(2, 4.0)]
+    [InlineData(3, 6.0)]
+    public void Compute_for_one_statistic_returns_computed_value_when_WithValue(int value, double expected)
+    {
+        var statistic = new Statistic<int>.WithValue(value);
+        var result = statistic.Compute(s => 2.0 * s);
+        result.Kind.Should().Be(StatisticKind.WithValue);
+        result.As<Statistic<double>.WithValue>().Value.Should().Be(expected);
+    }
+    
+    [Theory]
+    [InlineData(StatisticKind.Suppressed)]
+    [InlineData(StatisticKind.NotPublished)]
+    [InlineData(StatisticKind.NotApplicable)]
+    [InlineData(StatisticKind.NotAvailable)]
+    [InlineData(StatisticKind.NotYetSubmitted)]
+    public void Compute_for_two_statistics_propagates_kind_of_the_first_when_not_WithValue(StatisticKind kind)
+    {
+        var statistic1 = Statistic<int>.FromKind(kind);
+        var statistic2 = new Statistic<int>.WithValue(1);
+        var result = statistic1.Compute(statistic2, (s1, s2) => 2.0 * s1 + s2);
+        result.Kind.Should().Be(kind);
+    }
+    
+    [Theory]
+    [InlineData(StatisticKind.Suppressed)]
+    [InlineData(StatisticKind.NotPublished)]
+    [InlineData(StatisticKind.NotApplicable)]
+    [InlineData(StatisticKind.NotAvailable)]
+    [InlineData(StatisticKind.NotYetSubmitted)]
+    public void Compute_for_two_statistics_propagates_kind_of_the_second_when_not_WithValue(StatisticKind kind)
+    {
+        var statistic1 = new Statistic<int>.WithValue(1);
+        var statistic2 = Statistic<int>.FromKind(kind);
+        var result = statistic1.Compute(statistic2, (s1, s2) => 2.0 * s1 + s2);
+        result.Kind.Should().Be(kind);
+    }
+
+    [Fact]
+    public void Compute_for_two_statistics_when_both_not_WithValue_propagates_kind_of_the_first_statistic()
+    {
+        var statistic1 = Statistic<int>.FromKind(StatisticKind.NotPublished);
+        var statistic2 = Statistic<int>.FromKind(StatisticKind.Suppressed);
+        var result = statistic1.Compute(statistic2, (s1, s2) => 2.0 * s1 + s2);
+        result.Kind.Should().Be(StatisticKind.NotPublished);
+    }
+    
+    [Theory]
+    [InlineData(1, 2, 4.0)]
+    [InlineData(2, 4, 8.0)]
+    [InlineData(3, 6, 12.0)]
+    public void Compute_for_two_statistics_returns_computed_value_when_both_WithValue(int value1, int value2, double expected)
+    {
+        var statistic1 = new Statistic<int>.WithValue(value1);
+        var statistic2 = new Statistic<int>.WithValue(value2);
+        var result = statistic1.Compute(statistic2, (s1, s2) => 2.0 * s1 + s2);
+        result.Kind.Should().Be(StatisticKind.WithValue);
+        result.As<Statistic<double>.WithValue>().Value.Should().Be(expected);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/StatisticTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/StatisticTests.cs
@@ -1,0 +1,94 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
+
+public class StatisticTests
+{
+    [Fact]
+    public void WithValue_has_kind_of_WithValue()
+    {
+        var statistic = new Statistic<int>.WithValue(5);
+        statistic.Kind.Should().Be(StatisticKind.WithValue);
+    }
+
+    [Fact]
+    public void Suppressed_has_kind_of_Suppressed()
+    {
+        Statistic<int>.Suppressed.Kind.Should().Be(StatisticKind.Suppressed);
+    }
+    
+    [Fact]
+    public void NotPublished_has_kind_of_NotPublished()
+    {
+        Statistic<int>.NotPublished.Kind.Should().Be(StatisticKind.NotPublished);
+    }
+    
+    [Fact]
+    public void NotApplicable_has_kind_of_NotApplicable()
+    {
+        Statistic<int>.NotApplicable.Kind.Should().Be(StatisticKind.NotApplicable);
+    }
+    
+    [Fact]
+    public void NotAvailable_has_kind_of_NotAvailable()
+    {
+        Statistic<int>.NotAvailable.Kind.Should().Be(StatisticKind.NotAvailable);
+    }
+    
+    [Fact]
+    public void NotYetSubmitted_has_kind_of_NotYetSubmitted()
+    {
+        Statistic<int>.NotYetSubmitted.Kind.Should().Be(StatisticKind.NotYetSubmitted);
+    }
+
+    [Theory]
+    [InlineData(StatisticKind.Suppressed)]
+    [InlineData(StatisticKind.NotPublished)]
+    [InlineData(StatisticKind.NotApplicable)]
+    [InlineData(StatisticKind.NotAvailable)]
+    [InlineData(StatisticKind.NotYetSubmitted)]
+    public void FromKind_returns_statistic_of_correct_kind(StatisticKind kind)
+    {
+        Statistic<int>.FromKind(kind).Kind.Should().Be(kind);
+    }
+
+    [Fact]
+    public void FromKind_throws_ArgumentException_when_kind_is_WithValue()
+    {
+        Action action = () => Statistic<int>.FromKind(StatisticKind.WithValue);
+        action.Should().Throw<ArgumentException>().WithMessage(
+            "WithValue can't be constructed without a value. Use the WithValue constructor instead of this method."
+        );
+    }
+
+    [Fact]
+    public void FromKind_throws_ArgumentException_when_kind_is_unknown()
+    {
+        Action action = () => Statistic<int>.FromKind((StatisticKind) 999);
+        action.Should().Throw<ArgumentException>().WithMessage("Unknown statistic kind '999'.");
+    }
+
+    [Theory]
+    [InlineData(StatisticKind.Suppressed)]
+    [InlineData(StatisticKind.NotPublished)]
+    [InlineData(StatisticKind.NotApplicable)]
+    [InlineData(StatisticKind.NotAvailable)]
+    [InlineData(StatisticKind.NotYetSubmitted)]
+    public void TryGetValue_returns_false_when_kind_is_not_WithValue(StatisticKind kind)
+    {
+        var statistic = Statistic<int>.FromKind(kind);
+        
+        statistic.TryGetValue(out _).Should().BeFalse();
+    }
+    
+    [Theory]
+    [InlineData(5)]
+    [InlineData(10)]
+    [InlineData(15)]
+    public void TryGetValue_returns_true_and_returns_result_in_out_parameter_when_kind_is_WithValue(int value)
+    {
+        var statistic = new Statistic<int>.WithValue(value);
+        statistic.TryGetValue(out var result).Should().BeTrue();
+        result.Should().Be(value);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolPupilServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolPupilServiceTests.cs
@@ -1,0 +1,166 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
+
+public class SchoolPupilServiceTests
+{
+    private const int Urn = 123456;
+
+    private readonly SchoolPupilService _sut;
+    private readonly IDateTimeProvider _mockDateTimeProvider = Substitute.For<IDateTimeProvider>();
+    private readonly IPupilCensusRepository _mockPupilCensusRepository = Substitute.For<IPupilCensusRepository>();
+
+    private readonly SchoolPopulation _dummySchoolPopulation = new(
+        new Statistic<int>.WithValue(100),
+        new Statistic<int>.WithValue(10),
+        new Statistic<decimal>.WithValue(10.0m),
+        new Statistic<int>.WithValue(11),
+        new Statistic<decimal>.WithValue(11.0m),
+        new Statistic<int>.WithValue(12),
+        new Statistic<decimal>.WithValue(12.0m),
+        new Statistic<int>.WithValue(13),
+        new Statistic<decimal>.WithValue(13.0m)
+    );
+
+    public SchoolPupilServiceTests()
+    {
+        _mockPupilCensusRepository.GetSchoolPopulationStatisticsAsync(Arg.Any<int>())
+            .Returns(new AnnualStatistics<SchoolPopulation>());
+
+        var dummySchoolPopulationStatistics = new AnnualStatistics<SchoolPopulation>
+        {
+            { 2025, _dummySchoolPopulation },
+            { 2024, _dummySchoolPopulation },
+            { 2023, _dummySchoolPopulation },
+            { 2022, _dummySchoolPopulation },
+            { 2021, _dummySchoolPopulation },
+            { 2020, _dummySchoolPopulation },
+            { 2019, _dummySchoolPopulation },
+            { 2018, _dummySchoolPopulation },
+            { 2017, _dummySchoolPopulation },
+            { 2016, _dummySchoolPopulation },
+            { 2015, _dummySchoolPopulation }
+        };
+        _mockPupilCensusRepository.GetSchoolPopulationStatisticsAsync(Urn).Returns(dummySchoolPopulationStatistics);
+
+        _mockDateTimeProvider.Today.Returns(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        _sut = new SchoolPupilService(_mockDateTimeProvider, _mockPupilCensusRepository);
+    }
+
+    [Theory]
+    [InlineData(2019, 2024, 6)]
+    [InlineData(2014, 2018, 5)]
+    [InlineData(2009, 2012, 4)]
+    public async Task GetSchoolPopulationStatisticsAsync_returns_Unknown_results_when_no_data_for_the_urn_could_be_found(int from, int to, int expectedNumberOfYears)
+    {
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(999999, from, to);
+
+        result.Should().HaveCount(expectedNumberOfYears);
+        result.Values.Should().AllBeEquivalentTo(SchoolPopulation.Unknown);
+    }
+
+    [Theory]
+    [InlineData(2025)]
+    [InlineData(2020)]
+    [InlineData(2015)]
+    public async Task GetSchoolPopulationStatisticsAsync_returns_one_result_when_from_and_to_are_the_same_year(int year)
+    {
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(Urn, year, year);
+
+        result.Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData(2020, 2019)]
+    [InlineData(2025, 1999)]
+    public async Task
+        GetSchoolPopulationStatisticsAsync_throws_ArgumentOutOfRangeException_when_from_is_after_to(int from, int to)
+    {
+        var act = () => _sut.GetSchoolPopulationStatisticsAsync(Urn, from, to);
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>().WithMessage($"to.Value ('{to}') must be greater than or equal to '{from}'. (Parameter 'to.Value')\nActual value was {to}.");
+    }
+
+    [Fact]
+    public async Task GetSchoolPopulationStatisticsAsync_fills_in_future_years_with_NotYetSubmitted_SchoolPopulation()
+    {
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(Urn, 3000, 3005);
+        
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(6);
+        result.Values.Should().AllBeEquivalentTo(SchoolPopulation.NotYetSubmitted);
+    }
+
+    [Theory]
+    [InlineData(2025, 1, 1, 2024)]
+    [InlineData(2024, 6, 15, 2023)]
+    [InlineData(2023, 9, 30, 2022)]
+    public async Task GetSchoolPopulationStatisticsAsync_considers_this_years_result_to_be_NotYetSubmitted_when_today_is_before_october_31st(
+        int year,
+        int month,
+        int day,
+        int expectedMostRecentYearOfData
+    )
+    {
+        _mockDateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(Urn, 2021, 2025);
+
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(5);
+        foreach (var y in Enumerable.Range(2021, 5))
+        {
+            result[y].Should()
+                .BeEquivalentTo(y > expectedMostRecentYearOfData ? SchoolPopulation.NotYetSubmitted : _dummySchoolPopulation);
+        }
+    }
+
+    [Theory]
+    [InlineData(2025, 10, 31, 2025)]
+    [InlineData(2024, 11, 1, 2024)]
+    [InlineData(2023, 12, 31, 2023)]
+    public async Task GetSchoolPopulationStatisticsAsync_considers_this_years_result_to_be_available_when_today_is_october_31st_or_later(
+        int year,
+        int month,
+        int day,
+        int expectedMostRecentYearOfData
+    )
+    {
+        _mockDateTimeProvider.Today.Returns(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc));
+
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(Urn, 2021, 2025);
+
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(5);
+        foreach (var y in Enumerable.Range(2021, 5))
+        {
+            result[y].Should()
+                .BeEquivalentTo(y > expectedMostRecentYearOfData ? SchoolPopulation.NotYetSubmitted : _dummySchoolPopulation);
+        }
+    }
+
+    [Fact]
+    public async Task GetSchoolPopulationStatisticsAsync_fills_in_missing_years_with_Unknown_SchoolPopulation()
+    {
+        var populationStatistics = new AnnualStatistics<SchoolPopulation>
+        {
+            { 2023, _dummySchoolPopulation },
+            { 2021, _dummySchoolPopulation },
+            { 2020, _dummySchoolPopulation }
+        };
+
+        _mockPupilCensusRepository.GetSchoolPopulationStatisticsAsync(Urn).Returns(populationStatistics);
+
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(Urn, 2021, 2024);
+
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(4);
+        result[2024].Should().BeEquivalentTo(SchoolPopulation.Unknown);
+        result[2023].Should().BeEquivalentTo(_dummySchoolPopulation);
+        result[2022].Should().BeEquivalentTo(SchoolPopulation.Unknown);
+        result[2021].Should().BeEquivalentTo(_dummySchoolPopulation);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to retrieve population data from the spring census by [Compare school and college performance in England](https://www.compare-school-performance.service.gov.uk/) within the application.

> [!Note]
> See [User Story 233746](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/233746): Build: Update population table with Compare census data

## Changes

- The Academies `DbContext` has been updated to include the `edperf_mstr.edperf_fiat` table, which is represented by the `EdperfFiat` entity class.
- A `Statistic<T>` record has been introduced that represents the value from a column on the `edperf_fiat` table in a typed way so that it either contains the value itself or represents a value that has been withheld or is unavailable.
- A `CensusYear` record has been introduced that represents the year that a census was performed. It provides utilities to get the current year, as well as past or future years, from an `IDateTimeProvider`.
- An `AnnualStatistics<T>` class has been introduced that represents an annual series of data which can be indexed by the year.
- A `SchoolPopulation` record has been introduced to represent the columns on the `edperf_fiat` table which are relevant to the upcoming 'Pupil population' page. It also provides two placeholder values, `SchoolPopulation.Unknown` and `SchoolPopulation.NotYetSubmitted`, which have all statistics set to `NotAvailable` and `NotYetSubmitted` respectively.
- A `PupilCensusRepository` has been introduced which provides the `GetSchoolPopulationStatisticsAsync` method. This method returns all available census data for the school or academy with the given URN.
- A `SchoolPupilService` has been introduced with provides the `GetSchoolPopulationStatisticsAsync` method. This method filters out the result given by the `PupilCensusRepository` to within the range of years provided, and shapes the result by filling in missing years with `SchoolPopulation.Unknown` and future years with `SchoolPopulation.NotYetSubmitted`.

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
