### PR TITLE
Create page for population data from Compare

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data/Enums/Source.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Enums/Source.cs
@@ -11,5 +11,6 @@ public enum Source
     FiatDb,
     Prepare,
     Complete,
-    ManageFreeSchoolProjects
+    ManageFreeSchoolProjects,
+    CompareSchoolCollegePerformanceEngland
 }

--- a/DfE.FindInformationAcademiesTrusts/Extensions/StatisticDisplayExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/StatisticDisplayExtensions.cs
@@ -1,0 +1,50 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Extensions;
+
+public static class StatisticDisplayExtensions
+{
+    public static string SortValue<T>(this Statistic<T> statistic)
+    {
+        return statistic.Stringify(
+            "suppressed",
+            "not-published",
+            "not-applicable",
+            "not-available",
+            "not-yet-submitted"
+        );
+    }
+
+    public static string DisplayValue<T>(this Statistic<T> statistic)
+    {
+        return statistic.Stringify(
+            "Suppressed",
+            "Not published",
+            "Not applicable",
+            "Not available",
+            "Not yet submitted"
+        );
+    }
+
+    public static string DisplayValueWithPercentage(this Statistic<int> absolute, Statistic<decimal> percentage) =>
+        absolute.Compute(percentage, (count, percent) => $"{count} ({percent}%)").DisplayValue();
+
+    private static string Stringify<T>(this Statistic<T> statistic, string suppressed, string notPublished,
+        string notApplicable, string notAvailable, string notYetSubmitted)
+    {
+        if (statistic is Statistic<T>.WithValue v)
+        {
+            return v.Value?.ToString() ?? string.Empty;
+        }
+
+        return statistic.Kind switch
+        {
+            StatisticKind.Suppressed => suppressed,
+            StatisticKind.NotPublished => notPublished,
+            StatisticKind.NotApplicable => notApplicable,
+            StatisticKind.NotAvailable => notAvailable,
+            StatisticKind.NotYetSubmitted => notYetSubmitted,
+            _ => throw new ArgumentException($"Unknown statistic kind '{statistic.Kind}'.")
+        };
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Pupils/Population.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Pupils/Population.cshtml
@@ -1,0 +1,91 @@
+@page "/schools/pupils/population"
+@model PopulationModel
+
+@{
+  Layout = "_SchoolLayout";
+}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h3 class="govuk-heading-m" data-testid="subpage-header">Pupil population</h3>
+    <p class="govuk-body" data-testid="spring-census-text">The following data is taken from the spring census of each
+      year, where available.</p>
+
+    <table class="govuk-table" data-testid="population-census-table">
+
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          <span class="govuk-visually-hidden">Data type</span>
+        </th>
+        @foreach (var year in Model.PopulationData.Select(vm => vm.Year))
+        {
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none"
+              data-testid="@year-year-header">
+            @year
+          </th>
+        }
+      </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row" data-testid="number-of-pupils-on-role-row">
+        <td class="govuk-table__cell">Number of pupils on role (NOR)</td>
+        @foreach (var population in Model.PopulationData)
+        {
+          <td class="govuk-table__cell govuk-table__cell--numeric"
+              data-testid="@population.Year-number-of-pupils-on-role"
+              data-sort-value="@population.NumberOfPupilsOnRoleSort">
+            @population.NumberOfPupilsOnRoleDisplay
+          </td>
+        }
+      </tr>
+
+      <tr class="govuk-table__row" data-testid="eligible-pupils-with-ehc-plan-row">
+        <td class="govuk-table__cell">Eligible pupils with EHC plan</td>
+        @foreach (var population in Model.PopulationData)
+        {
+          <td class="govuk-table__cell govuk-table__cell--numeric"
+              data-testid="@population.Year-eligible-pupils-with-ehc-plan"
+              data-sort-value="@population.EligiblePupilsWithEhcPlanSort">
+            @population.EligiblePupilsWithEhcPlanDisplay
+          </td>
+        }
+      </tr>
+      <tr class="govuk-table__row" data-testid="eligible-pupils-with-sen-support-row">
+        <td class="govuk-table__cell">Eligible pupils with SEN support</td>
+        @foreach (var population in Model.PopulationData)
+        {
+          <td class="govuk-table__cell govuk-table__cell--numeric"
+              data-testid="@population.Year-eligible-pupils-with-sen-support"
+              data-sort-value="@population.EligiblePupilsWithSenSupportSort">
+            @population.EligiblePupilsWithSenSupportDisplay
+          </td>
+        }
+      </tr>
+      <tr class="govuk-table__row" data-testid="english-as-an-additional-language-row">
+        <td class="govuk-table__cell">English as an additional language</td>
+        @foreach (var population in Model.PopulationData)
+        {
+          <td class="govuk-table__cell govuk-table__cell--numeric"
+              data-testid="@population.Year-english-as-an-additional-language"
+              data-sort-value="@population.EnglishAsAnAdditionalLanguageSort">
+            @population.EnglishAsAnAdditionalLanguageDisplay
+          </td>
+        }
+      </tr>
+      <tr class="govuk-table__row" data-testid="eligible-for-free-school-meals-row">
+        <td class="govuk-table__cell">Eligible for free school meals</td>
+        @foreach (var population in Model.PopulationData)
+        {
+          <td class="govuk-table__cell govuk-table__cell--numeric"
+              data-testid="@population.Year-eligible-for-free-school-meals"
+              data-sort-value="@population.EligibleForFreeSchoolMealsSort">
+            @population.EligibleForFreeSchoolMealsDisplay
+          </td>
+        }
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Pupils/Population.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Pupils/Population.cshtml.cs
@@ -1,0 +1,79 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using DfE.FindInformationAcademiesTrusts.Extensions;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
+
+public class PopulationModel(
+    IDateTimeProvider dateTimeProvider,
+    ISchoolPupilService schoolPupilService,
+    IDataSourceService dataSourceService,
+    ISchoolService schoolService,
+    ITrustService trustService,
+    ISchoolNavMenu schoolNavMenu
+) : PupilsAreaModel(dataSourceService, schoolService, trustService, schoolNavMenu)
+{
+    public const string SubPageName = "Population";
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
+
+    public List<PopulationDataViewModel> PopulationData { get; set; } = null!;
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+        if (pageResult is NotFoundResult) return pageResult;
+
+        var statistics = await schoolPupilService.GetSchoolPopulationStatisticsAsync(
+            Urn,
+            CensusYear.Previous(dateTimeProvider, 3),
+            CensusYear.Next(dateTimeProvider)
+        );
+
+        PopulationData = statistics.OrderByDescending(kvp => kvp.Key.Value)
+            .Select(kvp => PopulationDataViewModel.FromSchoolPopulation(kvp.Key, kvp.Value))
+            .ToList();
+
+        return pageResult;
+    }
+}
+
+public record PopulationDataViewModel(
+    CensusYear Year,
+    string NumberOfPupilsOnRoleDisplay,
+    string NumberOfPupilsOnRoleSort,
+    string EligiblePupilsWithEhcPlanDisplay,
+    string EligiblePupilsWithEhcPlanSort,
+    string EligiblePupilsWithSenSupportDisplay,
+    string EligiblePupilsWithSenSupportSort,
+    string EnglishAsAnAdditionalLanguageDisplay,
+    string EnglishAsAnAdditionalLanguageSort,
+    string EligibleForFreeSchoolMealsDisplay,
+    string EligibleForFreeSchoolMealsSort
+)
+{
+    public static PopulationDataViewModel FromSchoolPopulation(CensusYear censusYear, SchoolPopulation schoolPopulation)
+    {
+        return new PopulationDataViewModel(
+            censusYear,
+            schoolPopulation.PupilsOnRole.DisplayValue(),
+            schoolPopulation.PupilsOnRole.SortValue(),
+            schoolPopulation.PupilsWithEhcPlan
+                .DisplayValueWithPercentage(schoolPopulation.PupilsWithEhcPlanPercentage),
+            schoolPopulation.PupilsWithEhcPlan.SortValue(),
+            schoolPopulation.PupilsWithSenSupport
+                .DisplayValueWithPercentage(schoolPopulation.PupilsWithSenSupportPercentage),
+            schoolPopulation.PupilsWithSenSupport.SortValue(),
+            schoolPopulation.PupilsWithEnglishAsAdditionalLanguage
+                .DisplayValueWithPercentage(schoolPopulation.PupilsWithEnglishAsAdditionalLanguagePercentage),
+            schoolPopulation.PupilsWithEnglishAsAdditionalLanguage.SortValue(),
+            schoolPopulation.PupilsEligibleForFreeSchoolMeals
+                .DisplayValueWithPercentage(schoolPopulation.PupilsEligibleForFreeSchoolMealsPercentage),
+            schoolPopulation.PupilsEligibleForFreeSchoolMeals.SortValue()
+        );
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Pupils/PupilsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Pupils/PupilsAreaModel.cs
@@ -1,0 +1,34 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+using Source = DfE.FindInformationAcademiesTrusts.Data.Enums.Source;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
+
+public class PupilsAreaModel(
+    IDataSourceService dataSourceService,
+    ISchoolService schoolService,
+    ITrustService trustService,
+    ISchoolNavMenu schoolNavMenu
+) : SchoolAreaModel(schoolService, trustService, schoolNavMenu)
+{
+    public const string PageName = "Pupils";
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+        if (pageResult is NotFoundResult) return pageResult;
+
+        var compareDataSource = await dataSourceService.GetAsync(Source.CompareSchoolCollegePerformanceEngland);
+
+        DataSourcesPerPage.AddRange([
+            new DataSourcePageListEntry(PopulationModel.SubPageName, [new DataSourceListEntry(compareDataSource)]),
+        ]);
+
+        return Page();
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
@@ -5,6 +5,7 @@ using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Governance;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.NavMenu;
 using Microsoft.FeatureManagement;
 using GovernanceAreaModel = DfE.FindInformationAcademiesTrusts.Pages.Schools.Governance.GovernanceAreaModel;
@@ -29,6 +30,7 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
         [
             GetServiceNavLinkTo<OverviewAreaModel>(OverviewAreaModel.PageName, "/Schools/Overview/Details",
                 activePage),
+            GetServiceNavLinkTo<PupilsAreaModel>(PupilsAreaModel.PageName, "/Schools/Pupils/Population", activePage),
             GetServiceNavLinkTo<ContactsAreaModel>(ContactsAreaModel.PageName, contactLink, activePage),
             GetServiceNavLinkTo<GovernanceAreaModel>(GovernanceAreaModel.PageName, "/Schools/Governance/Current",
                 activePage),
@@ -52,6 +54,7 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
         return activePage switch
         {
             OverviewAreaModel => BuildLinksForOverviewPage(activePage),
+            PupilsAreaModel => BuildLinksForPupilsPage(activePage),
             ContactsAreaModel => await BuildLinksForContactsPageAsync(activePage),
             GovernanceAreaModel governanceAreaModel => BuildLinksForGovernancePage(governanceAreaModel),
             OfstedAreaModel => BuildLinksForOfstedPage(activePage),
@@ -110,6 +113,18 @@ public class SchoolNavMenu(IVariantFeatureManager featureManager) : ISchoolNavMe
 
 
         return links.ToArray();
+    }
+
+    private static NavLink[] BuildLinksForPupilsPage(ISchoolAreaModel activePage)
+    {
+        return
+        [
+            GetSubNavLinkTo<PopulationModel>(PupilsAreaModel.PageName,
+                PopulationModel.SubPageName,
+                "/Schools/Pupils/Population",
+                activePage,
+                "pupils-population-subnav")
+        ];
     }
 
     private async Task<NavLink[]> BuildLinksForContactsPageAsync(ISchoolAreaModel activePage)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/DataSourceListEntry.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/DataSource/DataSourceListEntry.cs
@@ -43,6 +43,7 @@ public record DataSourceListEntry(List<DataSourceServiceModel> DataSources, stri
             Source.Prepare => "Prepare",
             Source.Complete => "Complete",
             Source.ManageFreeSchoolProjects => "Manage free school projects",
+            Source.CompareSchoolCollegePerformanceEngland => "Compare school and college performance in England",
             _ => "Unknown"
         };
     }

--- a/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceService.cs
@@ -29,11 +29,16 @@ public class DataSourceService(
 
         var dataSource = source switch
         {
-            Source.Gias or Source.Mstr or Source.Cdm or Source.Mis or Source.MisFurtherEducation =>
-                await dataSourceRepository.GetAsync(source),
+            Source.Gias
+                or Source.Mstr
+                or Source.Cdm
+                or Source.Mis
+                or Source.MisFurtherEducation
+                or Source.Prepare
+                or Source.Complete
+                or Source.ManageFreeSchoolProjects
+                or Source.CompareSchoolCollegePerformanceEngland => await dataSourceRepository.GetAsync(source),
             Source.ExploreEducationStatistics => freeSchoolMealsAverageProvider.GetFreeSchoolMealsUpdated(),
-            Source.Prepare or Source.Complete or Source.ManageFreeSchoolProjects =>
-                await dataSourceRepository.GetAsync(source),
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
         };
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/DataSourceRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/DataSourceRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.DataSource;
 using Microsoft.Extensions.Logging;
@@ -37,6 +38,7 @@ public class DataSourceRepositoryTests
     [InlineData(Source.Prepare, UpdateFrequency.Daily)]
     [InlineData(Source.Complete, UpdateFrequency.Daily)]
     [InlineData(Source.ManageFreeSchoolProjects, UpdateFrequency.Daily)]
+    [InlineData(Source.CompareSchoolCollegePerformanceEngland, UpdateFrequency.Annually)]
     public async Task GetAsync_WhenEntryExists_ShouldReturnLatestSuccessfullyFinishedDataSourceUpdate(Source source,
         UpdateFrequency updateFrequency)
     {
@@ -67,6 +69,7 @@ public class DataSourceRepositoryTests
     [InlineData(Source.Complete, "Unable to find last data refresh for MSTR source 'Complete'", UpdateFrequency.Daily)]
     [InlineData(Source.ManageFreeSchoolProjects,
         "Unable to find last data refresh for MSTR source 'ManageFreeSchoolProjects'", UpdateFrequency.Daily)]
+    [InlineData(Source.CompareSchoolCollegePerformanceEngland, "Unable to find when Compare School and College Performance in England dataset was last ingested", UpdateFrequency.Annually)]
     public async Task GetAsync_WhenNoEntryForPipelineExists_ShouldReturnDataSource_WithNullDate_AndLogError(
         Source source, string expectedErrorMessage, UpdateFrequency updateFrequency)
     {
@@ -106,6 +109,12 @@ public class DataSourceRepositoryTests
         _mockAcademiesDbContext.AddMstrAcademyTransfer("", "", true, false, lastDataRefresh: updateTime);
         _mockAcademiesDbContext.AddMstrAcademyTransfer("", "", false, true, lastDataRefresh: updateTime);
         _mockAcademiesDbContext.AddMstrFreeSchoolProject("", "", lastDataRefresh: updateTime);
+        _mockAcademiesDbContext.EdperfFiats.Add(new EdperfFiat
+        {
+            MetaCensusIngestionDatetime = updateTime,
+            Urn = 100000,
+            DownloadYear = "2025-2026"
+        });
     }
 
     private void AddSuccessfulDataSourceUpdatesExceptFor(Source source)
@@ -124,5 +133,12 @@ public class DataSourceRepositoryTests
             _mockAcademiesDbContext.AddMstrAcademyTransfer("", "", false, true, lastDataRefresh: lastUpdateTime);
         if (source is not Source.ManageFreeSchoolProjects)
             _mockAcademiesDbContext.AddMstrFreeSchoolProject("", "", lastDataRefresh: lastUpdateTime);
+        if (source is not Source.CompareSchoolCollegePerformanceEngland)
+            _mockAcademiesDbContext.EdperfFiats.Add(new EdperfFiat
+            {
+                MetaCensusIngestionDatetime = lastUpdateTime,
+                Urn = 100000,
+                DownloadYear = "2025-2026"
+            });
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/StatisticDisplayExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/StatisticDisplayExtensionsTests.cs
@@ -1,0 +1,97 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using DfE.FindInformationAcademiesTrusts.Extensions;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Extensions;
+
+public class StatisticDisplayExtensionsTests
+{
+    [Theory]
+    [InlineData(StatisticKind.Suppressed, "suppressed")]
+    [InlineData(StatisticKind.NotPublished, "not-published")]
+    [InlineData(StatisticKind.NotApplicable, "not-applicable")]
+    [InlineData(StatisticKind.NotAvailable, "not-available")]
+    [InlineData(StatisticKind.NotYetSubmitted, "not-yet-submitted")]
+    public void SortValue_returns_expected_value_for_statistics_without_value(StatisticKind kind, string expected)
+    {
+        var statistic = Statistic<int>.FromKind(kind);
+        
+        statistic.SortValue().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, "1")]
+    [InlineData(3.4, "3.4")]
+    [InlineData(true, "True")]
+    [InlineData("Text", "Text")]
+    public void SortValue_returns_expected_value_for_statistics_with_value(object value, string expected)
+    {
+        var statistic = new Statistic<object>.WithValue(value);
+        
+        statistic.SortValue().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StatisticKind.Suppressed, "Suppressed")]
+    [InlineData(StatisticKind.NotPublished, "Not published")]
+    [InlineData(StatisticKind.NotApplicable, "Not applicable")]
+    [InlineData(StatisticKind.NotAvailable, "Not available")]
+    [InlineData(StatisticKind.NotYetSubmitted, "Not yet submitted")]
+    public void DisplayValue_returns_expected_value_for_statistics_without_value(StatisticKind kind, string expected)
+    {
+        var statistic = Statistic<int>.FromKind(kind);
+        
+        statistic.DisplayValue().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, "1")]
+    [InlineData(3.4, "3.4")]
+    [InlineData(true, "True")]
+    [InlineData("Text", "Text")]
+    public void DisplayValue_returns_expected_value_for_statistics_with_value(object value, string expected)
+    {
+        var statistic = new Statistic<object>.WithValue(value);
+        
+        statistic.DisplayValue().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StatisticKind.Suppressed,  "Suppressed")]
+    [InlineData(StatisticKind.NotPublished, "Not published")]
+    [InlineData(StatisticKind.NotApplicable, "Not applicable")]
+    [InlineData(StatisticKind.NotAvailable, "Not available")]
+    [InlineData(StatisticKind.NotYetSubmitted, "Not yet submitted")]
+    public void DisplayValueWithPercentage_returns_expected_value_when_first_statistic_does_not_have_a_value(StatisticKind kind, string expected)
+    {
+        var statistic1 = Statistic<int>.FromKind(kind);
+        var statistic2 = new Statistic<decimal>.WithValue(2.0m);
+        
+        statistic1.DisplayValueWithPercentage(statistic2).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StatisticKind.Suppressed,  "Suppressed")]
+    [InlineData(StatisticKind.NotPublished, "Not published")]
+    [InlineData(StatisticKind.NotApplicable, "Not applicable")]
+    [InlineData(StatisticKind.NotAvailable, "Not available")]
+    [InlineData(StatisticKind.NotYetSubmitted, "Not yet submitted")]
+    public void DisplayValueWithPercentage_returns_expected_value_when_second_statistic_does_not_have_a_value(StatisticKind kind, string expected)
+    {
+        var statistic1 = new Statistic<int>.WithValue(2);
+        var statistic2 = Statistic<decimal>.FromKind(kind);
+        
+        statistic1.DisplayValueWithPercentage(statistic2).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(2, "1.0", "2 (1.0%)")]
+    [InlineData(566, "17.4", "566 (17.4%)")]
+    [InlineData(94, "2.94", "94 (2.94%)")]
+    public void DisplayValueWithPercentage_returns_expected_value_when_both_statistics_have_a_value(int value1, string value2, string expected)
+    {
+        var statistic1 = new Statistic<int>.WithValue(value1);
+        var statistic2 = new Statistic<decimal>.WithValue(decimal.Parse(value2));
+        
+        statistic1.DisplayValueWithPercentage(statistic2).Should().Be(expected);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
@@ -44,6 +44,7 @@ public static class MockDataSourceService
             Source.Mis => UpdateFrequency.Monthly,
             Source.MisFurtherEducation => UpdateFrequency.Monthly,
             Source.ExploreEducationStatistics => UpdateFrequency.Annually,
+            Source.CompareSchoolCollegePerformanceEngland => UpdateFrequency.Annually,
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
         });
     }
@@ -58,4 +59,7 @@ public static class MockDataSourceService
 
     public static DataSourceServiceModel ManageFreeSchool { get; } =
         GetDummyDataSource(Source.ManageFreeSchoolProjects);
+    
+    public static DataSourceServiceModel CompareSchoolCollegePerformanceEngland { get; } =
+        GetDummyDataSource(Source.CompareSchoolCollegePerformanceEngland);
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Pupils/BasePupilsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Pupils/BasePupilsAreaModelTests.cs
@@ -1,0 +1,68 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Pupils;
+
+public abstract class BasePupilsAreaModelTests<T> : BaseSchoolPageTests<T> where T : PupilsAreaModel
+{
+    protected readonly IDateTimeProvider MockDateTimeProvider = Substitute.For<IDateTimeProvider>();
+    protected readonly ISchoolPupilService MockSchoolPupilService = Substitute.For<ISchoolPupilService>();
+    
+    protected readonly SchoolPopulation DummySchoolPopulation = new(
+        new Statistic<int>.WithValue(1000),
+        new Statistic<int>.WithValue(100),
+        new Statistic<decimal>.WithValue(10.0m),
+        new Statistic<int>.WithValue(111),
+        new Statistic<decimal>.WithValue(11.1m),
+        new Statistic<int>.WithValue(123),
+        new Statistic<decimal>.WithValue(12.3m),
+        new Statistic<int>.WithValue(135),
+        new Statistic<decimal>.WithValue(13.5m)
+    );
+
+    protected BasePupilsAreaModelTests()
+    {
+        MockDateTimeProvider.Today.Returns(new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        MockSchoolPupilService
+            .GetSchoolPopulationStatisticsAsync(Arg.Any<int>(), Arg.Any<CensusYear>(), Arg.Any<CensusYear>())
+            .Returns(call =>
+            {
+                var from = call.ArgAt<CensusYear>(1);
+                var to = call.ArgAt<CensusYear>(2);
+
+                var result = new AnnualStatistics<SchoolPopulation>();
+                foreach (var year in Enumerable.Range(from.Value, to.Value - from.Value + 1))
+                {
+                    result[year] = DummySchoolPopulation;
+                }
+
+                return result;
+            });
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_PageMetadata_PageName()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.PageName.Should().Be("Pupils");
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_sets_correct_data_source_list()
+    {
+        await Task.CompletedTask;
+        _ = await Sut.OnGetAsync();
+        await MockDataSourceService.Received(1).GetAsync(Source.CompareSchoolCollegePerformanceEngland);
+
+        Sut.DataSourcesPerPage.Should().BeEquivalentTo([
+            new DataSourcePageListEntry("Population", [
+                new DataSourceListEntry(Mocks.MockDataSourceService.CompareSchoolCollegePerformanceEngland)
+            ])
+        ]);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Pupils/PopulationModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Pupils/PopulationModelTests.cs
@@ -1,0 +1,106 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Pupils;
+
+public class PopulationModelTests : BasePupilsAreaModelTests<PopulationModel>
+{
+    public PopulationModelTests()
+    {
+        Sut = new PopulationModel(
+            MockDateTimeProvider,
+            MockSchoolPupilService,
+            MockDataSourceService,
+            MockSchoolService,
+            MockTrustService,
+            MockSchoolNavMenu)
+        {
+            Urn = SchoolUrn
+        };
+    }
+
+    public override async Task OnGetAsync_should_configure_PageMetadata_SubPageName()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.SubPageName.Should().Be("Population");
+    }
+
+    [Theory]
+    [InlineData(2025, 2021)]
+    [InlineData(2030, 2026)]
+    [InlineData(2020, 2016)]
+    public async Task OnGetAsync_should_set_correct_population_data_for_current_time(int latestYear, int earliestYear)
+    {
+        MockDateTimeProvider.Today.Returns(new DateTime(latestYear, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var expectedNumberOfYears = latestYear - earliestYear + 1;
+        var expectedPopulationDataViewModels = Enumerable
+            .Range(earliestYear, expectedNumberOfYears).Select(year =>
+                new PopulationDataViewModel(
+                    year,
+                    "1000",
+                    "1000",
+                    "100 (10.0%)",
+                    "100",
+                    "111 (11.1%)",
+                    "111",
+                    "123 (12.3%)",
+                    "123",
+                    "135 (13.5%)",
+                    "135"
+                ));
+
+        await Sut.OnGetAsync();
+
+        Sut.PopulationData.Should().NotBeNull();
+        Sut.PopulationData.Should().HaveCount(expectedNumberOfYears);
+        Sut.PopulationData.Should().BeEquivalentTo(expectedPopulationDataViewModels);
+    }
+
+    [Theory]
+    [InlineData(StatisticKind.Suppressed, "Suppressed", "suppressed")]
+    [InlineData(StatisticKind.NotPublished, "Not published", "not-published")]
+    [InlineData(StatisticKind.NotApplicable, "Not applicable", "not-applicable")]
+    [InlineData(StatisticKind.NotAvailable, "Not available", "not-available")]
+    [InlineData(StatisticKind.NotYetSubmitted, "Not yet submitted", "not-yet-submitted")]
+    public async Task OnGetAsync_should_set_correct_population_data_for_statistics_without_values(StatisticKind kind,
+        string expectedDisplayValue, string expectedSortValue)
+    {
+        var schoolPopulation = new SchoolPopulation(
+            Statistic<int>.FromKind(kind),
+            Statistic<int>.FromKind(kind),
+            Statistic<decimal>.FromKind(kind),
+            Statistic<int>.FromKind(kind),
+            Statistic<decimal>.FromKind(kind),
+            Statistic<int>.FromKind(kind),
+            Statistic<decimal>.FromKind(kind),
+            Statistic<int>.FromKind(kind),
+            Statistic<decimal>.FromKind(kind)
+        );
+
+        var expectedPopulationDataViewModel = new PopulationDataViewModel(
+            2025,
+            expectedDisplayValue,
+            expectedSortValue,
+            expectedDisplayValue,
+            expectedSortValue,
+            expectedDisplayValue,
+            expectedSortValue,
+            expectedDisplayValue,
+            expectedSortValue,
+            expectedDisplayValue,
+            expectedSortValue
+        );
+
+        MockSchoolPupilService
+            .GetSchoolPopulationStatisticsAsync(Arg.Any<int>(), Arg.Any<CensusYear>(), Arg.Any<CensusYear>())
+            .Returns(new AnnualStatistics<SchoolPopulation> { [2025] = schoolPopulation });
+
+        await Sut.OnGetAsync();
+
+        Sut.PopulationData.Should().NotBeNull();
+        Sut.PopulationData.Should().HaveCount(1);
+        Sut.PopulationData[0].Should().BeEquivalentTo(expectedPopulationDataViewModel);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Governance;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMenu;
 
@@ -72,6 +73,12 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
             },
             l =>
             {
+                l.LinkDisplayText.Should().Be("Pupils");
+                l.AspPage.Should().Be("/Schools/Pupils/Population");
+                l.TestId.Should().Be("pupils-nav");
+            },
+            l =>
+            {
                 l.LinkDisplayText.Should().Be("Contacts");
                 l.AspPage.Should().Be("/Schools/Contacts/InSchool");
                 l.TestId.Should().Be("contacts-nav");
@@ -106,6 +113,12 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
                 l.LinkDisplayText.Should().Be("Overview");
                 l.AspPage.Should().Be("/Schools/Overview/Details");
                 l.TestId.Should().Be("overview-nav");
+            },
+            l =>
+            {
+                l.LinkDisplayText.Should().Be("Pupils");
+                l.AspPage.Should().Be("/Schools/Pupils/Population");
+                l.TestId.Should().Be("pupils-nav");
             },
             l =>
             {
@@ -172,6 +185,7 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
             nameof(SenModel) => "/Schools/Overview/Details",
             nameof(FederationModel) => "/Schools/Overview/Details",
             nameof(ReferenceNumbersModel) => "/Schools/Overview/Details",
+            nameof(PopulationModel) => "/Schools/Pupils/Population",
             nameof(CurrentModel) => "/Schools/Governance/Current",
             nameof(HistoricModel) => "/Schools/Governance/Current",
             nameof(SingleHeadlineGradesModel) => "/Schools/Ofsted/SingleHeadlineGrades",

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
@@ -6,6 +6,7 @@ using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Governance;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
 using DfE.FindInformationAcademiesTrusts.Services.School;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMenu;
@@ -52,6 +53,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
             nameof(FederationModel) => "Overview",
             nameof(ReferenceNumbersModel) => "Overview",
             nameof(ReligiousCharacteristicsModel) => "Overview",
+            nameof(PopulationModel) => "Pupils",
             nameof(CurrentModel) => "Governance",
             nameof(HistoricModel) => "Governance",
             nameof(SingleHeadlineGradesModel) => "Ofsted",
@@ -102,6 +104,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
             nameof(SenModel) => "/Schools/Overview/Sen",
             nameof(FederationModel) => "/Schools/Overview/Federation",
             nameof(ReferenceNumbersModel) => "/Schools/Overview/ReferenceNumbers",
+            nameof(PopulationModel) => "/Schools/Pupils/Population",
             nameof(CurrentModel) => "/Schools/Governance/Current",
             nameof(HistoricModel) => "/Schools/Governance/Historic",
             nameof(SingleHeadlineGradesModel) => "/Schools/Ofsted/SingleHeadlineGrades",

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Governance;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Pupils;
 using DfE.FindInformationAcademiesTrusts.Services.School;
 using Microsoft.FeatureManagement;
 using Sut = DfE.FindInformationAcademiesTrusts.Pages.Schools.SchoolNavMenu;
@@ -27,6 +28,8 @@ public abstract class SchoolNavMenuTestsBase
         typeof(SenModel),
         typeof(FederationModel),
         typeof(ReferenceNumbersModel),
+        // Pupils
+        typeof(PopulationModel),
         //Contacts
         typeof(InSchoolModel),
         // Governance
@@ -45,6 +48,8 @@ public abstract class SchoolNavMenuTestsBase
         typeof(DetailsModel),
         typeof(SenModel),
         typeof(ReferenceNumbersModel),
+        // Pupils
+        typeof(PopulationModel),
         //Contacts
         typeof(InDfeModel),
         typeof(InSchoolModel),

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/DataSource/DataSourceListEntryTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/DataSource/DataSourceListEntryTest.cs
@@ -66,6 +66,7 @@ public class DataSourceListEntryTest
         "Further education and skills inspections and outcomes: management information")]
     [InlineData(Source.ExploreEducationStatistics, "Explore education statistics")]
     [InlineData(Source.FiatDb, "Find information about schools and trusts")]
+    [InlineData(Source.CompareSchoolCollegePerformanceEngland, "Compare school and college performance in England")]
     public void GetName_should_return_the_correct_string_for_each_source(Source source, string expected)
     {
         DataSourceListEntry.GetName(_dataSourceServiceModel with { Source = source }).Should().Be(expected);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
@@ -32,7 +32,8 @@ public class DataSourceServiceTests
         { Source.Mis, GetDummyDataSource(Source.Mis, UpdateFrequency.Monthly) },
         { Source.MisFurtherEducation, GetDummyDataSource(Source.MisFurtherEducation, UpdateFrequency.Monthly) },
         { Source.Mstr, GetDummyDataSource(Source.Mstr, UpdateFrequency.Daily) },
-        { Source.Prepare, GetDummyDataSource(Source.Prepare, UpdateFrequency.Daily) }
+        { Source.Prepare, GetDummyDataSource(Source.Prepare, UpdateFrequency.Daily) },
+        { Source.CompareSchoolCollegePerformanceEngland, GetDummyDataSource(Source.CompareSchoolCollegePerformanceEngland, UpdateFrequency.Annually) }
     };
 
     private readonly DataSource _dummyInternalContactDataSource =
@@ -47,14 +48,15 @@ public class DataSourceServiceTests
         [
             Source.Cdm, Source.Complete, Source.Gias, Source.ManageFreeSchoolProjects, Source.Mis,
             Source.MisFurtherEducation, Source.Mstr,
-            Source.Prepare
+            Source.Prepare,
+            Source.CompareSchoolCollegePerformanceEngland,
         ];
 
         _mockDataSourceRepository.GetAsync(Arg.Is<Source>(source => supportedAcademiesDbSources.Contains(source)))
             .Returns(callInfo => _dummyDataSources[callInfo.Arg<Source>()]);
 
         _mockDataSourceRepository.GetAsync(Arg.Is<Source>(source => !supportedAcademiesDbSources.Contains(source)))
-            .ThrowsAsync(new ArgumentOutOfRangeException());
+            .ThrowsAsync(new Exception("Source isn't in supportedAcademiesDbSources. If a test fails unexpectedly with this message, it probably should be added to the list."));
 
         _mockFreeSchoolMealsAverageProvider.GetFreeSchoolMealsUpdated()
             .Returns(_dummyDataSources[Source.ExploreEducationStatistics]);
@@ -82,6 +84,7 @@ public class DataSourceServiceTests
     [InlineData(Source.Mis, UpdateFrequency.Monthly)]
     [InlineData(Source.MisFurtherEducation, UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, UpdateFrequency.Daily)]
+    [InlineData(Source.CompareSchoolCollegePerformanceEngland, UpdateFrequency.Annually)]
     public async Task GetAsync_cached_should_return_cached_result(Source source, UpdateFrequency updateFrequency)
     {
         var dataSource = new DataSourceServiceModel(source, new DateTime(2024, 01, 01), updateFrequency);
@@ -102,6 +105,7 @@ public class DataSourceServiceTests
     [InlineData(Source.MisFurtherEducation, UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, UpdateFrequency.Daily)]
     [InlineData(Source.Prepare, UpdateFrequency.Daily)]
+    [InlineData(Source.CompareSchoolCollegePerformanceEngland, UpdateFrequency.Annually)]
     public async Task GetAsync_uncached_should_call_dataSourceRepository(Source source, UpdateFrequency updateFrequency)
     {
         var expectedCacheTimeSpan =
@@ -126,6 +130,7 @@ public class DataSourceServiceTests
     [InlineData(Source.MisFurtherEducation)]
     [InlineData(Source.Mstr)]
     [InlineData(Source.Prepare)]
+    [InlineData(Source.CompareSchoolCollegePerformanceEngland)]
     public async Task GetAsync_uncached_should_call_academiesDbDataSourceRepository(Source source)
     {
         var result = await _sut.GetAsync(source);
@@ -144,6 +149,7 @@ public class DataSourceServiceTests
     [InlineData(Source.MisFurtherEducation, UpdateFrequency.Monthly)]
     [InlineData(Source.Mstr, UpdateFrequency.Daily)]
     [InlineData(Source.Prepare, UpdateFrequency.Daily)]
+    [InlineData(Source.CompareSchoolCollegePerformanceEngland, UpdateFrequency.Annually)]
     public async Task GetAsync_uncached_should_cache_result(Source source, UpdateFrequency updateFrequency)
     {
         var expectedCacheTimeSpan =


### PR DESCRIPTION
This PR introduces the `/schools/pupils/population` page so that users can view the population data from the spring census by [Compare school and college performance in England](https://www.compare-school-performance.service.gov.uk/).

> [!Note]
> See [User Story 233746](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/233746): Build: Update population table with Compare census data

## Changes

- A new `Source.CompareSchoolCollegePerformanceEngland` data source has been added to represent this data.
- A `PupilsAreaModel` class has been introduced to provide common functionality to all views within the 'Pupils' area for a school.
- A `Population.cshtml` Razor view and `PopulationModel` view model have been introduced to retrieve and present the population data.
- A `StatisticDisplayExtensions` utility class has been introduced, which provides ways of transforming a `Statistic<T>` into user-facing text.
- A new 'Pupils' section has been added to the main navigation menu for schools pages, directly after the 'Overview' link. The 'Population' page is the default active page for this link.
- A new 'Population' link has been added to the subnavigation menu for the 'Pupils' section.

## Screenshots of UI changes

The 'Pupil population' page:
<img width="2419" height="2536" alt="" src="https://github.com/user-attachments/assets/d3e9d382-cf99-4f26-9785-9086b2f5ca01" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
