### PR TITLE
Deploy and run CI pipelines for PRs targeting `feature/**` branches

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -2,7 +2,7 @@ name: .NET
 
 on:
   pull_request:
-    branches: [ main, '**-feature' ]
+    branches: [ main, 'feature/**' ]
     paths:
       - '**.cs'
       - '**.cshtml'

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -2,7 +2,7 @@ name: Deploy to environment
 
 on:
   pull_request:
-    branches: [ main, '**-feature' ]
+    branches: [ main, 'feature/**' ]
   push:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
Currently, when creating a pull request that targets another branch (i.e. merging into a branch other than `main`), only a subset of the pipelines are run, which reduces confidence in larger pieces of work and occasionally leads to edits being necessary after merging in.

However, it appears that some attempt was made to address this issue previously, as some of the `.github/workflows` definitions have `**-feature` as a filter for pull requests. This doesn't match the convention for naming branches used in this project, however, so this has been changed to instead match `feature/**` to restore its intended functionality.