### PR TITLE
Get pupil numbers for trusts from Compare census data

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/IPupilCensusRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/IPupilCensusRepository.cs
@@ -4,4 +4,5 @@ public interface IPupilCensusRepository
 {
     public Task<AnnualStatistics<SchoolPopulation>> GetSchoolPopulationStatisticsAsync(int urn);
     public Task<AnnualStatistics<Attendance>> GetAttendanceStatisticsAsync(int urn);
+    public Task<TrustStatistics<SchoolPopulation>> GetMostRecentPopulationStatisticsForTrustAsync(string uid);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/TrustStatistics.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/PupilCensus/TrustStatistics.cs
@@ -1,0 +1,3 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+public class TrustStatistics<T> : Dictionary<int, T>;

--- a/DfE.FindInformationAcademiesTrusts/Extensions/StatisticDisplayExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/StatisticDisplayExtensions.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 
 namespace DfE.FindInformationAcademiesTrusts.Extensions;
@@ -24,6 +25,11 @@ public static class StatisticDisplayExtensions
             "Not available",
             "Not yet submitted"
         );
+    }
+
+    public static string DisplayPercentage<T>(this Statistic<T> statistic) where T: INumber<T>
+    {
+        return statistic.Compute(s => $"{s}%").DisplayValue();
     }
 
     public static string DisplayValueWithPercentage(this Statistic<int> absolute, Statistic<decimal> percentage) =>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
@@ -34,6 +34,7 @@ public abstract class AcademiesInTrustAreaModel(
 
         var giasDataSource = await DataSourceService.GetAsync(Source.Gias);
         var eesDataSource = await DataSourceService.GetAsync(Source.ExploreEducationStatistics);
+        var compareDataSource = await DataSourceService.GetAsync(Source.CompareSchoolCollegePerformanceEnglandPopulation);
 
         TabList =
         [
@@ -45,7 +46,10 @@ public abstract class AcademiesInTrustAreaModel(
         DataSourcesPerPage.AddRange([
             new DataSourcePageListEntry(AcademiesInTrustDetailsModel.TabName,
                 [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(PupilNumbersModel.TabName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(PupilNumbersModel.TabName, [
+                new DataSourceListEntry(compareDataSource, "Pupil numbers"),
+                new DataSourceListEntry(giasDataSource, "All other information was")
+            ]),
             new DataSourcePageListEntry(FreeSchoolMealsModel.TabName, [
                 new DataSourceListEntry(giasDataSource, "Pupils eligible for free school meals"),
                 new DataSourceListEntry(eesDataSource, "Local authority average 2023/24"),

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml
@@ -36,16 +36,11 @@
         </td>
 
         <td class="govuk-body govuk-table__cell" data-sort-value="@academy.NumberOfPupils"
-            data-testid="pupil-numbers">@academy.NumberOfPupils?.ToString("N0")</td>
+            data-testid="pupil-numbers">@academy.NumberOfPupils.DisplayValue()</td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@academy.SchoolCapacity"
             data-testid="pupil-capacity">@academy.SchoolCapacity?.ToString("N0")</td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@academy.PercentageFull"
-            data-testid="percentage-full">
-          @if (academy.PercentageFull is not null)
-          {
-            @($"{academy.PercentageFull?.ToString("N0")}%")
-          }
-        </td>
+            data-testid="percentage-full">@academy.PercentageFull.DisplayPercentage()</td>
       </tr>
     }
     </tbody>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
@@ -28,7 +28,7 @@ public class OverviewAreaModel(
 
         // Add data sources
         var giasDataSource = await DataSourceService.GetAsync(Source.Gias);
-        var compareDataSource = await DataSourceService.GetAsync(Source.CompareSchoolCollegePerformanceEngland);
+        var compareDataSource = await DataSourceService.GetAsync(Source.CompareSchoolCollegePerformanceEnglandPopulation);
         DataSourcesPerPage.AddRange([
             new DataSourcePageListEntry(TrustDetailsModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
             new DataSourcePageListEntry(TrustSummaryModel.SubPageName, [new DataSourceListEntry(compareDataSource, "Pupil numbers"), new DataSourceListEntry(giasDataSource, "All other information was")]),

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
@@ -28,9 +28,10 @@ public class OverviewAreaModel(
 
         // Add data sources
         var giasDataSource = await DataSourceService.GetAsync(Source.Gias);
+        var compareDataSource = await DataSourceService.GetAsync(Source.CompareSchoolCollegePerformanceEngland);
         DataSourcesPerPage.AddRange([
             new DataSourcePageListEntry(TrustDetailsModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(TrustSummaryModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(TrustSummaryModel.SubPageName, [new DataSourceListEntry(compareDataSource, "Pupil numbers"), new DataSourceListEntry(giasDataSource, "All other information was")]),
             new DataSourcePageListEntry(ReferenceNumbersModel.SubPageName, [new DataSourceListEntry(giasDataSource)])
         ]);
 

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyPupilNumbersServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyPupilNumbersServiceModel.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.Academy;
 
@@ -7,21 +8,19 @@ public record AcademyPupilNumbersServiceModel(
     string? EstablishmentName,
     string? PhaseOfEducation,
     AgeRange AgeRange,
-    int? NumberOfPupils,
+    Statistic<int> NumberOfPupils,
     int? SchoolCapacity
 )
 {
-    public float? PercentageFull
+    public Statistic<float> PercentageFull
     {
         get
         {
-            if (this is { NumberOfPupils: not null, SchoolCapacity: not null } &&
-                SchoolCapacity != 0)
-            {
-                return (float)Math.Round((int)NumberOfPupils / (float)SchoolCapacity * 100);
-            }
+            var schoolCapacity = SchoolCapacity is not null and not 0
+                ? new Statistic<int>.WithValue((int)SchoolCapacity)
+                : Statistic<int>.NotAvailable;
 
-            return null;
+            return NumberOfPupils.Compute(schoolCapacity, (nop, sc) => (float)Math.Round(nop / (float)sc * 100.0f));
         }
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
@@ -2,6 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.Academy;
 
@@ -47,7 +48,10 @@ public class AcademyService(
 
         return academies.Select(a =>
             new AcademyPupilNumbersServiceModel(a.Urn, a.EstablishmentName, a.PhaseOfEducation,
-                a.AgeRange, a.NumberOfPupils,
+                a.AgeRange,
+                a.NumberOfPupils is null
+                    ? Statistic<int>.NotAvailable
+                    : new Statistic<int>.WithValue((int)a.NumberOfPupils),
                 a.SchoolCapacity)).ToArray();
     }
 

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
@@ -3,6 +3,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.Academy;
 
@@ -22,6 +23,7 @@ public class AcademyService(
     IAcademyRepository academyRepository,
     IOfstedRepository ofstedRepository,
     IPipelineEstablishmentRepository pipelineEstablishmentRepository,
+    ITrustPupilService trustPupilService,
     IFreeSchoolMealsAverageProvider freeSchoolMealsAverageProvider) : IAcademyService
 {
     public async Task<AcademyDetailsServiceModel[]> GetAcademiesInTrustDetailsAsync(string uid)
@@ -45,14 +47,18 @@ public class AcademyService(
     public async Task<AcademyPupilNumbersServiceModel[]> GetAcademiesInTrustPupilNumbersAsync(string uid)
     {
         var academies = await academyRepository.GetAcademiesInTrustPupilNumbersAsync(uid);
+        var pupilNumbers = await trustPupilService.GetPupilCountsForSchoolsInTrustAsync(uid);
 
         return academies.Select(a =>
-            new AcademyPupilNumbersServiceModel(a.Urn, a.EstablishmentName, a.PhaseOfEducation,
-                a.AgeRange,
-                a.NumberOfPupils is null
-                    ? Statistic<int>.NotAvailable
-                    : new Statistic<int>.WithValue((int)a.NumberOfPupils),
-                a.SchoolCapacity)).ToArray();
+            new AcademyPupilNumbersServiceModel(a.Urn, a.EstablishmentName, a.PhaseOfEducation, a.AgeRange,
+                GetNumberOfPupils(a), a.SchoolCapacity)).ToArray();
+
+        Statistic<int> GetNumberOfPupils(AcademyPupilNumbers p)
+        {
+            if (!int.TryParse(p.Urn, out var urn)) return Statistic<int>.NotAvailable;
+
+            return pupilNumbers.TryGetValue(urn, out var value) ? value : Statistic<int>.NotAvailable;
+        }
     }
 
     public async Task<AcademyFreeSchoolMealsServiceModel[]> GetAcademiesInTrustFreeSchoolMealsAsync(string uid)

--- a/DfE.FindInformationAcademiesTrusts/Services/Export/AcademiesExportService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/AcademiesExportService.cs
@@ -85,7 +85,7 @@ public class AcademiesExportService(ITrustService trustService, IAcademyService 
     {
         var previousRating = ofstedData?.PreviousOfstedRating;
         var currentRating = ofstedData?.CurrentOfstedRating;
-        var percentageFull = pupilNumbersData?.PercentageFull ?? 0;
+        var percentageFull = pupilNumbersData?.PercentageFull;
 
         SetTextCell(AcademyColumns.SchoolName, academy.EstablishmentName ?? string.Empty);
         SetTextCell(AcademyColumns.Urn, academy.Urn);
@@ -117,9 +117,9 @@ public class AcademiesExportService(ITrustService trustService, IAcademyService 
 
         SetTextCell(AcademyColumns.AgeRange, pupilNumbersData?.AgeRange.ToTabularDisplayString() ?? string.Empty);
 
-        SetTextCell(AcademyColumns.PupilNumbers, pupilNumbersData?.NumberOfPupils?.ToString() ?? string.Empty);
+        SetTextCell(AcademyColumns.PupilNumbers, pupilNumbersData?.NumberOfPupils.DisplayValue() ?? string.Empty);
         SetTextCell(AcademyColumns.Capacity, pupilNumbersData?.SchoolCapacity?.ToString() ?? string.Empty);
-        SetTextCell(AcademyColumns.PercentFull, percentageFull > 0 ? $"{percentageFull}%" : string.Empty);
+        SetTextCell(AcademyColumns.PercentFull, percentageFull?.DisplayPercentage() ?? string.Empty);
         SetTextCell(AcademyColumns.PupilsEligibleFreeSchoolMeals,
             freeSchoolMealsData is { PercentageFreeSchoolMeals: not null }
                 ? $"{freeSchoolMealsData.PercentageFreeSchoolMeals}%"

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustPupilService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustPupilService.cs
@@ -1,0 +1,32 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.Trust;
+
+public interface ITrustPupilService
+{
+    Task<int> GetTotalPupilCountForTrustAsync(string uid);
+    Task<TrustStatistics<Statistic<int>>> GetPupilCountsForSchoolsInTrustAsync(string uid);
+}
+
+public class TrustPupilService(IPupilCensusRepository pupilCensusRepository) : ITrustPupilService
+{
+    public async Task<int> GetTotalPupilCountForTrustAsync(string uid)
+    {
+        var statistics = await pupilCensusRepository.GetMostRecentPopulationStatisticsForTrustAsync(uid);
+
+        return statistics.Values.Sum(sp => sp.PupilsOnRole.TryGetValue(out var value) ? value : 0);
+    }
+
+    public async Task<TrustStatistics<Statistic<int>>> GetPupilCountsForSchoolsInTrustAsync(string uid)
+    {
+        var statistics = await pupilCensusRepository.GetMostRecentPopulationStatisticsForTrustAsync(uid);
+
+        var result = new TrustStatistics<Statistic<int>>();
+        foreach (var (urn, sp) in statistics)
+        {
+            result.Add(urn, sp.PupilsOnRole);
+        }
+
+        return result;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -27,6 +27,7 @@ public class TrustService(
     ITrustRepository trustRepository,
     ITrustGovernanceRepository trustGovernanceRepository,
     IContactRepository contactRepository,
+    ITrustPupilService trustPupilService,
     IMemoryCache memoryCache,
     IDateTimeProvider dateTimeProvider)
     : ITrustService
@@ -131,7 +132,7 @@ public class TrustService(
             .GroupBy(a => a.LocalAuthority)
             .ToDictionary(g => g.Key, g => g.Count());
 
-        var totalPupilNumbers = academiesOverview.Sum(a => a.NumberOfPupils ?? 0);
+        var totalPupilNumbers = await trustPupilService.GetTotalPupilCountForTrustAsync(uid);
         var totalCapacity = academiesOverview.Sum(a => a.SchoolCapacity ?? 0);
 
         var overviewModel = new TrustOverviewServiceModel(

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -96,6 +96,7 @@ public static class Dependencies
         builder.Services.AddScoped<IFinancialDocumentService, FinancialDocumentService>();
         builder.Services.AddScoped<ISchoolService, SchoolService>();
         builder.Services.AddScoped<ISchoolPupilService, SchoolPupilService>();
+        builder.Services.AddScoped<ITrustPupilService, TrustPupilService>();
 
         builder.Services.AddScoped<IPipelineAcademiesExportService, PipelineAcademiesExportService>();
         builder.Services.AddScoped<IOfstedTrustDataExportService, OfstedTrustDataExportService>();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PupilCensusRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PupilCensusRepositoryTests.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Edperf_Mstr;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 
@@ -6,8 +7,13 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Reposito
 
 public class PupilCensusRepositoryTests
 {
-    private const int Urn = 123456;
+    private const int SchoolUrn = 123456;
 
+    private const int AcademyUrn1 = 234567;
+    private const int AcademyUrn2 = 345678;
+    
+    private const string Uid = "1234";
+    
     private readonly PupilCensusRepository _sut;
     private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
 
@@ -15,7 +21,7 @@ public class PupilCensusRepositoryTests
     [
         new()
         {
-            Urn = Urn,
+            Urn = SchoolUrn,
             DownloadYear = "2020-2021",
             CensusNor = "100",
             CensusTsenelse = "10",
@@ -32,7 +38,7 @@ public class PupilCensusRepositoryTests
         },
         new()
         {
-            Urn = Urn,
+            Urn = SchoolUrn,
             DownloadYear = "2021-2022",
             CensusNor = "200",
             CensusTsenelse = "20",
@@ -49,7 +55,7 @@ public class PupilCensusRepositoryTests
         },
         new()
         {
-            Urn = Urn,
+            Urn = SchoolUrn,
             DownloadYear = "2022-2023",
             CensusNor = "300",
             CensusTsenelse = "30",
@@ -66,7 +72,7 @@ public class PupilCensusRepositoryTests
         },
         new()
         {
-            Urn = Urn,
+            Urn = SchoolUrn,
             DownloadYear = "2023-2024",
             CensusNor = "400",
             CensusTsenelse = "40",
@@ -83,7 +89,7 @@ public class PupilCensusRepositoryTests
         },
         new()
         {
-            Urn = Urn,
+            Urn = SchoolUrn,
             DownloadYear = "2024-2025",
             CensusNor = "500",
             CensusTsenelse = "50",
@@ -97,6 +103,48 @@ public class PupilCensusRepositoryTests
             AbsencePpersabs10 = "55.0",
             MetaCensusIngestionDatetime = DateTime.Parse("2024-08-31"),
             MetaAbsenceIngestionDatetime = DateTime.Parse("2024-08-31")
+        },
+        new()
+        {
+            Urn = AcademyUrn1,
+            DownloadYear = "2020-2021",
+            CensusNor = "600",
+            CensusTsenelse = "60",
+            CensusPsenelse = "60.0",
+            CensusTsenelk = "61",
+            CensusPsenelk = "61.0",
+            CensusNumeal = "62",
+            CensusPnumeal = "62.0",
+            CensusNumfsm = "63",
+            AbsencePerctot = "64.0",
+        },
+        new()
+        {
+            Urn = AcademyUrn2,
+            DownloadYear = "2021-2022",
+            CensusNor = "700",
+            CensusTsenelse = "70",
+            CensusPsenelse = "70.0",
+            CensusTsenelk = "71",
+            CensusPsenelk = "71.0",
+            CensusNumeal = "72",
+            CensusPnumeal = "72.0",
+            CensusNumfsm = "73",
+            AbsencePerctot = "74.0",
+        },
+        new()
+        {
+            Urn = AcademyUrn2,
+            DownloadYear = "2022-2023",
+            CensusNor = "800",
+            CensusTsenelse = "80",
+            CensusPsenelse = "80.0",
+            CensusTsenelk = "81",
+            CensusPsenelk = "81.0",
+            CensusNumeal = "82",
+            CensusPnumeal = "82.0",
+            CensusNumfsm = "83",
+            AbsencePerctot = "84.0",
         }
     ];
 
@@ -215,9 +263,46 @@ public class PupilCensusRepositoryTests
             }
         };
 
+    private readonly Dictionary<int, SchoolPopulation> _dummySchoolPopulationsForTrust =
+        new()
+        {
+            {
+                AcademyUrn1,
+                new SchoolPopulation(
+                    new Statistic<int>.WithValue(600),
+                    new Statistic<int>.WithValue(60),
+                    new Statistic<decimal>.WithValue(60.0m),
+                    new Statistic<int>.WithValue(61),
+                    new Statistic<decimal>.WithValue(61.0m),
+                    new Statistic<int>.WithValue(62),
+                    new Statistic<decimal>.WithValue(62.0m),
+                    new Statistic<int>.WithValue(63),
+                    new Statistic<decimal>.WithValue(63.0m)
+                )
+            },
+            {
+                AcademyUrn2,
+                new SchoolPopulation(
+                    new Statistic<int>.WithValue(800),
+                    new Statistic<int>.WithValue(80),
+                    new Statistic<decimal>.WithValue(80.0m),
+                    new Statistic<int>.WithValue(81),
+                    new Statistic<decimal>.WithValue(81.0m),
+                    new Statistic<int>.WithValue(82),
+                    new Statistic<decimal>.WithValue(82.0m),
+                    new Statistic<int>.WithValue(83),
+                    new Statistic<decimal>.WithValue(83.0m)
+                )
+            }
+        };
+
     public PupilCensusRepositoryTests()
     {
         _mockAcademiesDbContext.EdperfFiats.AddRange(_dummyEdperfFiats);
+        _mockAcademiesDbContext.GiasGroupLinks.AddRange([
+            new GiasGroupLink { GroupUid = Uid, Urn = AcademyUrn1.ToString(), GroupStatusCode = "OPEN", JoinedDate = "01/01/2020" },
+            new GiasGroupLink { GroupUid = Uid, Urn = AcademyUrn2.ToString(), GroupStatusCode = "OPEN", JoinedDate = "01/01/2020" }
+        ]);
 
         _sut = new PupilCensusRepository(_mockAcademiesDbContext.Object);
     }
@@ -237,14 +322,14 @@ public class PupilCensusRepositoryTests
         mockDbContext.EdperfFiats.AddRange([
             new EdperfFiat
             {
-                Urn = Urn,
+                Urn = SchoolUrn,
                 DownloadYear = "2019-2020"
             }
         ]);
 
         var sut = new PupilCensusRepository(mockDbContext.Object);
 
-        var result = await sut.GetSchoolPopulationStatisticsAsync(Urn);
+        var result = await sut.GetSchoolPopulationStatisticsAsync(SchoolUrn);
 
         result.Should().NotBeEmpty();
         result.Should().HaveCount(1);
@@ -255,8 +340,7 @@ public class PupilCensusRepositoryTests
     public async Task
         GetSchoolPopulationStatisticsAsync_should_return_school_population_statistics_when_school_is_found()
     {
-        var result = await _sut.GetSchoolPopulationStatisticsAsync(Urn);
-
+        var result = await _sut.GetSchoolPopulationStatisticsAsync(SchoolUrn);
         result.Should().BeEquivalentTo(_dummySchoolPopulations);
     }
 
@@ -274,7 +358,7 @@ public class PupilCensusRepositoryTests
         mockDbContext.EdperfFiats.AddRange([
             new EdperfFiat
             {
-                Urn = Urn,
+                Urn = SchoolUrn,
                 DownloadYear = "2019-2020",
                 CensusNor = statisticValue,
                 CensusTsenelse = statisticValue,
@@ -289,8 +373,7 @@ public class PupilCensusRepositoryTests
 
         var sut = new PupilCensusRepository(mockDbContext.Object);
 
-        var result = await sut.GetSchoolPopulationStatisticsAsync(Urn);
-
+        var result = await sut.GetSchoolPopulationStatisticsAsync(SchoolUrn);
         result.Should().NotBeEmpty();
         result.Should().HaveCount(1);
         result[2020].PupilsOnRole.Should().Be(Statistic<int>.FromKind(expectedKind));
@@ -312,7 +395,7 @@ public class PupilCensusRepositoryTests
         mockDbContext.EdperfFiats.AddRange([
             new EdperfFiat
             {
-                Urn = Urn,
+                Urn = SchoolUrn,
                 DownloadYear = "2019-2020",
                 CensusNor = "100",
                 CensusTsenelse = "10",
@@ -327,8 +410,7 @@ public class PupilCensusRepositoryTests
 
         var sut = new PupilCensusRepository(mockDbContext.Object);
 
-        var result = await sut.GetSchoolPopulationStatisticsAsync(Urn);
-
+        var result = await sut.GetSchoolPopulationStatisticsAsync(SchoolUrn);
         result.Should().NotBeEmpty();
         result.Should().HaveCount(1);
         result[2020].PupilsWithEhcPlanPercentage.Should().Be(new Statistic<decimal>.WithValue(10.0m));
@@ -353,14 +435,14 @@ public class PupilCensusRepositoryTests
         mockDbContext.EdperfFiats.AddRange([
             new EdperfFiat
             {
-                Urn = Urn,
+                Urn = SchoolUrn,
                 DownloadYear = "2019-2020"
             }
         ]);
 
         var sut = new PupilCensusRepository(mockDbContext.Object);
 
-        var result = await sut.GetAttendanceStatisticsAsync(Urn);
+        var result = await sut.GetAttendanceStatisticsAsync(SchoolUrn);
 
         result.Should().NotBeEmpty();
         result.Should().HaveCount(1);
@@ -370,7 +452,7 @@ public class PupilCensusRepositoryTests
     [Fact]
     public async Task GetAttendanceStatisticsAsync_should_return_attendance_statistics_when_school_is_found()
     {
-        var result = await _sut.GetAttendanceStatisticsAsync(Urn);
+        var result = await _sut.GetAttendanceStatisticsAsync(SchoolUrn);
 
         result.Should().BeEquivalentTo(_dummyAttendances);
     }
@@ -389,7 +471,7 @@ public class PupilCensusRepositoryTests
         mockDbContext.EdperfFiats.AddRange([
             new EdperfFiat
             {
-                Urn = Urn,
+                Urn = SchoolUrn,
                 DownloadYear = "2019-2020",
                 AbsencePerctot = statisticValue,
                 AbsencePpersabs10 = statisticValue
@@ -398,7 +480,7 @@ public class PupilCensusRepositoryTests
 
         var sut = new PupilCensusRepository(mockDbContext.Object);
 
-        var result = await sut.GetAttendanceStatisticsAsync(Urn);
+        var result = await sut.GetAttendanceStatisticsAsync(SchoolUrn);
 
         result.Should().NotBeEmpty();
         result.Should().HaveCount(1);
@@ -414,7 +496,7 @@ public class PupilCensusRepositoryTests
         mockDbContext.EdperfFiats.AddRange([
             new EdperfFiat
             {
-                Urn = Urn,
+                Urn = SchoolUrn,
                 DownloadYear = "2019-2020",
                 AbsencePerctot = "10.0%",
                 AbsencePpersabs10 = "11.0%"
@@ -423,11 +505,104 @@ public class PupilCensusRepositoryTests
 
         var sut = new PupilCensusRepository(mockDbContext.Object);
 
-        var result = await sut.GetAttendanceStatisticsAsync(Urn);
+        var result = await sut.GetAttendanceStatisticsAsync(SchoolUrn);
 
         result.Should().NotBeEmpty();
         result.Should().HaveCount(1);
         result[2019].OverallAbsencePercentage.Should().Be(new Statistic<decimal>.WithValue(10.0m));
         result[2019].EnrolmentsWhoArePersistentAbsenteesPercentage.Should().Be(new Statistic<decimal>.WithValue(11.0m));
+    }
+
+    [Fact]
+    public async Task GetMostRecentPopulationStatisticsForTrustAsync_should_return_empty_when_trust_is_not_found()
+    {
+        var result = await _sut.GetMostRecentPopulationStatisticsForTrustAsync("9999");
+        
+        result.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public async Task GetMostRecentPopulationStatisticsForTrustAsync_should_return_trust_population_statistics_when_trust_is_found()
+    {
+        var result = await _sut.GetMostRecentPopulationStatisticsForTrustAsync(Uid);
+        
+        result.Should().BeEquivalentTo(_dummySchoolPopulationsForTrust);
+    }
+    
+    [Theory]
+    [InlineData("SUPP", StatisticKind.Suppressed)]
+    [InlineData("NP", StatisticKind.NotPublished)]
+    [InlineData("NA", StatisticKind.NotApplicable)]
+    [InlineData("Other text", StatisticKind.NotAvailable)]
+    [InlineData("Different text", StatisticKind.NotAvailable)]
+    [InlineData("", StatisticKind.NotAvailable)]
+    public async Task GetMostRecentPopulationStatisticsForTrustAsync_parses_statistics_without_values_correctly(string statisticValue, StatisticKind expectedKind)
+    {
+        var mockDbContext = new MockAcademiesDbContext();
+        mockDbContext.EdperfFiats.AddRange([
+            new EdperfFiat
+            {
+                Urn = AcademyUrn1,
+                DownloadYear = "2019-2020",
+                CensusNor = statisticValue,
+                CensusTsenelse = statisticValue,
+                CensusPsenelse = statisticValue,
+                CensusTsenelk = statisticValue,
+                CensusPsenelk = statisticValue,
+                CensusNumeal = statisticValue,
+                CensusPnumeal = statisticValue,
+                CensusNumfsm = statisticValue,
+            }
+        ]);
+        mockDbContext.GiasGroupLinks.Add(new GiasGroupLink { GroupUid = Uid, Urn = AcademyUrn1.ToString(), GroupStatusCode = "OPEN", JoinedDate = "01/01/2020" });
+
+        var sut = new PupilCensusRepository(mockDbContext.Object);
+        
+        var result = await sut.GetMostRecentPopulationStatisticsForTrustAsync(Uid);
+        
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(1);
+        result[AcademyUrn1].PupilsOnRole.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsWithEhcPlan.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsWithEhcPlanPercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsWithSenSupport.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsWithSenSupportPercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsWithEnglishAsAdditionalLanguage.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsWithEnglishAsAdditionalLanguagePercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsEligibleForFreeSchoolMeals.Should().Be(Statistic<int>.FromKind(expectedKind));
+        result[AcademyUrn1].PupilsEligibleForFreeSchoolMealsPercentage.Should().Be(Statistic<decimal>.FromKind(expectedKind));
+    }
+
+    [Fact]
+    public async Task GetMostRecentPopulationStatisticsForTrustAsync_parses_decimal_statistics_with_percent_signs_correctly()
+    {
+        var mockDbContext = new MockAcademiesDbContext();
+        mockDbContext.EdperfFiats.AddRange([
+            new EdperfFiat
+            {
+                Urn = AcademyUrn2,
+                DownloadYear = "2019-2020",
+                CensusNor = "100",
+                CensusTsenelse = "10",
+                CensusPsenelse = "10.0%",
+                CensusTsenelk = "11",
+                CensusPsenelk = "11.0%",
+                CensusNumeal = "12",
+                CensusPnumeal = "12.0%",
+                CensusNumfsm = "13",
+            }
+        ]);
+        mockDbContext.GiasGroupLinks.Add(new GiasGroupLink { GroupUid = Uid, Urn = AcademyUrn2.ToString(), GroupStatusCode = "OPEN", JoinedDate = "01/01/2020" });
+
+        var sut = new PupilCensusRepository(mockDbContext.Object);
+        
+        var result = await sut.GetMostRecentPopulationStatisticsForTrustAsync(Uid);
+        
+        result.Should().NotBeEmpty();
+        result.Should().HaveCount(1);
+        result[AcademyUrn2].PupilsWithEhcPlanPercentage.Should().Be(new Statistic<decimal>.WithValue(10.0m));
+        result[AcademyUrn2].PupilsWithSenSupportPercentage.Should().Be(new Statistic<decimal>.WithValue(11.0m));
+        result[AcademyUrn2].PupilsWithEnglishAsAdditionalLanguagePercentage.Should().Be(new Statistic<decimal>.WithValue(12.0m));
+        result[AcademyUrn2].PupilsEligibleForFreeSchoolMealsPercentage.Should().Be(new Statistic<decimal>.WithValue(13.0m));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/StatisticDisplayExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/StatisticDisplayExtensionsTests.cs
@@ -56,6 +56,29 @@ public class StatisticDisplayExtensionsTests
     }
 
     [Theory]
+    [InlineData(StatisticKind.Suppressed, "Suppressed")]
+    [InlineData(StatisticKind.NotPublished, "Not published")]
+    [InlineData(StatisticKind.NotApplicable, "Not applicable")]
+    [InlineData(StatisticKind.NotAvailable, "Not available")]
+    [InlineData(StatisticKind.NotYetSubmitted, "Not yet submitted")]
+    public void DisplayPercentage_returns_expected_value_for_statistics_without_value(StatisticKind kind, string expected)
+    {
+        var statistic = Statistic<float>.FromKind(kind);
+        
+        statistic.DisplayValue().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, "1%")]
+    [InlineData(3.4, "3.4%")]
+    public void DisplayPercentage_returns_expected_value_for_statistics_with_value(double value, string expected)
+    {
+        var statistic = new Statistic<double>.WithValue(value);
+        
+        statistic.DisplayPercentage().Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData(StatisticKind.Suppressed,  "Suppressed")]
     [InlineData(StatisticKind.NotPublished, "Not published")]
     [InlineData(StatisticKind.NotApplicable, "Not applicable")]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
@@ -87,7 +87,10 @@ public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModel
             new DataSourcePageListEntry("Details",
                 [new DataSourceListEntry(GiasDataSource)]),
             new DataSourcePageListEntry("Pupil numbers",
-                [new DataSourceListEntry(GiasDataSource)]),
+            [
+                new DataSourceListEntry(CompareDataSource, "Pupil numbers"),
+                new DataSourceListEntry(GiasDataSource, "All other information was")
+            ]),
             new DataSourcePageListEntry("Free school meals",
             [
                 new DataSourceListEntry(GiasDataSource, "Pupils eligible for free school meals"),

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies.InTrust;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 
@@ -28,7 +29,7 @@ public class PupilNumbersModelTests : AcademiesInTrustAreaModelTests<PupilNumber
         var ageRange = new AgeRange(minAge, maxAge);
         var testAcademyUrn = "1234";
         var testAcademyName = "Test Academy";
-        var testAcademyNumberOfPupils = 100;
+        var testAcademyNumberOfPupils = new Statistic<int>.WithValue(100);
         var testAcademySchoolCapacity = 100;
 
         var result = PupilNumbersModel.PhaseAndAgeRangeSortValue(new AcademyPupilNumbersServiceModel(testAcademyUrn,
@@ -40,7 +41,7 @@ public class PupilNumbersModelTests : AcademiesInTrustAreaModelTests<PupilNumber
     [Fact]
     public override async Task OnGetAsync_sets_academies_from_academyService()
     {
-        var academy = new AcademyPupilNumbersServiceModel("", null, null, new AgeRange(5, 11), null, null);
+        var academy = new AcademyPupilNumbersServiceModel("", null, null, new AgeRange(5, 11), Statistic<int>.NotAvailable, null);
         var academies = new[]
         {
             academy with { Urn = "1" },

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
@@ -25,6 +25,9 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     protected readonly DataSourceServiceModel EesDataSource = new(Source.ExploreEducationStatistics,
         new DateTime(2023, 11, 9), UpdateFrequency.Annually);
 
+    protected readonly DataSourceServiceModel CompareDataSource =
+        new(Source.CompareSchoolCollegePerformanceEngland, new DateTime(2023, 11, 9), UpdateFrequency.Annually);
+
     protected const string TrustUid = "1234";
     protected readonly TrustSummaryServiceModel DummyTrustSummary = new(TrustUid, "My Trust", "Multi-academy trust", 3);
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
@@ -26,7 +26,7 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
         new DateTime(2023, 11, 9), UpdateFrequency.Annually);
 
     protected readonly DataSourceServiceModel CompareDataSource =
-        new(Source.CompareSchoolCollegePerformanceEngland, new DateTime(2023, 11, 9), UpdateFrequency.Annually);
+        new(Source.CompareSchoolCollegePerformanceEnglandPopulation, new DateTime(2023, 11, 9), UpdateFrequency.Annually);
 
     protected const string TrustUid = "1234";
     protected readonly TrustSummaryServiceModel DummyTrustSummary = new(TrustUid, "My Trust", "Multi-academy trust", 3);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
@@ -31,7 +31,7 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseTrustPageTests<T>, ITe
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry("Trust details", [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry("Trust summary", [new DataSourceListEntry(GiasDataSource)]),
+            new DataSourcePageListEntry("Trust summary", [new DataSourceListEntry(CompareDataSource, "Pupil numbers"), new DataSourceListEntry(GiasDataSource, "All other information was")]),
             new DataSourcePageListEntry("Reference numbers", [new DataSourceListEntry(GiasDataSource)])
         ]);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
@@ -2,6 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
@@ -89,13 +90,18 @@ public class AcademyServiceTests
             BuildDummyAcademyPupilNumbers("9876", "phase1", new AgeRange(2, 15), 100, 200),
             BuildDummyAcademyPupilNumbers("8765", "phase2", new AgeRange(7, 12), 2, 5)
         ];
-
+AcademyPupilNumbersServiceModel[] expected =
+        [
+            new("9876", "Academy 9876", "phase1", new AgeRange(2, 15), new Statistic<int>.WithValue(100), 200),
+            new("8765", "Academy 8765", "phase2", new AgeRange(7, 12), new Statistic<int>.WithValue(2), 5)
+        ];
+        
         _mockAcademyRepository.GetAcademiesInTrustPupilNumbersAsync(uid).Returns(academies);
 
         var result = await _sut.GetAcademiesInTrustPupilNumbersAsync(uid);
 
         result.Should().BeOfType<AcademyPupilNumbersServiceModel[]>();
-        result.Should().BeEquivalentTo(academies);
+        result.Should().BeEquivalentTo(expected);
     }
 
     private static AcademyPupilNumbers BuildDummyAcademyPupilNumbers(string urn,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/AcademiesExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/AcademiesExportServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using ClosedXML.Excel;
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Exceptions;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -73,7 +74,7 @@ public class AcademiesExportServiceTests
                 new OfstedRating(1, now.AddDays(-1)), new OfstedRating(1, now), false)
         ]);
         _mockAcademyService.GetAcademiesInTrustPupilNumbersAsync(trustUid).Returns([
-            new AcademyPupilNumbersServiceModel("123456", "Academy 1", "Primary", new AgeRange(5, 11), 500, 600)
+            new AcademyPupilNumbersServiceModel("123456", "Academy 1", "Primary", new AgeRange(5, 11), new Statistic<int>.WithValue(500), 600)
         ]);
         _mockAcademyService.GetAcademiesInTrustFreeSchoolMealsAsync(trustUid)
             .Returns([new AcademyFreeSchoolMealsServiceModel("123456", "Academy 1", 20, 25, 15)]);
@@ -149,7 +150,7 @@ public class AcademiesExportServiceTests
                 new OfstedRating(-1, null), new OfstedRating(-1, null), false)
         ]);
         _mockAcademyService.GetAcademiesInTrustPupilNumbersAsync(trustUid)
-            .Returns([new AcademyPupilNumbersServiceModel("123456", null, null, new AgeRange(5, 11), null, null)]);
+            .Returns([new AcademyPupilNumbersServiceModel("123456", null, null, new AgeRange(5, 11), Statistic<int>.NotAvailable, null)]);
         _mockAcademyService.GetAcademiesInTrustFreeSchoolMealsAsync(trustUid)
             .Returns([new AcademyFreeSchoolMealsServiceModel("123456", null, null, 0, 0)]);
 
@@ -176,9 +177,9 @@ public class AcademiesExportServiceTests
 
         worksheet.CellValue(4, AcademyColumns.PhaseOfEducation).Should().Be(string.Empty);
         worksheet.CellValue(4, AcademyColumns.AgeRange).Should().Be("5-11");
-        worksheet.CellValue(4, AcademyColumns.PupilNumbers).Should().Be(string.Empty);
+        worksheet.CellValue(4, AcademyColumns.PupilNumbers).Should().Be("Not available");
         worksheet.CellValue(4, AcademyColumns.Capacity).Should().Be(string.Empty);
-        worksheet.CellValue(4, AcademyColumns.PercentFull).Should().Be(string.Empty);
+        worksheet.CellValue(4, AcademyColumns.PercentFull).Should().Be("Not available");
         worksheet.CellValue(4, AcademyColumns.PupilsEligibleFreeSchoolMeals).Should().Be(string.Empty);
         worksheet.CellValue(4, AcademyColumns.LaPupilsEligibleFreeSchoolMeals).Should().Be(string.Empty);
         worksheet.CellValue(4, AcademyColumns.NationalPupilsEligibleFreeSchoolMeals).Should().Be(string.Empty);
@@ -194,7 +195,7 @@ public class AcademiesExportServiceTests
         _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid).Returns([]);
 
         _mockAcademyService.GetAcademiesInTrustPupilNumbersAsync(trustUid).Returns([
-            new AcademyPupilNumbersServiceModel("123456", "Academy 1", "Primary", new AgeRange(5, 11), 500, 600)
+            new AcademyPupilNumbersServiceModel("123456", "Academy 1", "Primary", new AgeRange(5, 11), new Statistic<int>.WithValue(500), 600)
         ]);
         _mockAcademyService.GetAcademiesInTrustFreeSchoolMealsAsync(trustUid)
             .Returns([new AcademyFreeSchoolMealsServiceModel("123456", "Academy 1", 20, 25, 15)]);
@@ -266,7 +267,7 @@ public class AcademiesExportServiceTests
         ]);
 
         _mockAcademyService.GetAcademiesInTrustPupilNumbersAsync(trustUid).Returns([
-            new AcademyPupilNumbersServiceModel("123456", "Academy 1", "Primary", new AgeRange(5, 11), 500, 600)
+            new AcademyPupilNumbersServiceModel("123456", "Academy 1", "Primary", new AgeRange(5, 11), new Statistic<int>.WithValue(500), 600)
         ]);
 
         _mockAcademyService.GetAcademiesInTrustFreeSchoolMealsAsync(trustUid).Returns([]);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustPupilServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustPupilServiceTests.cs
@@ -1,0 +1,139 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.PupilCensus;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
+
+public class TrustPupilServiceTests
+{
+    private const string Uid = "1234";
+
+    private readonly TrustPupilService _sut;
+    private readonly IPupilCensusRepository _mockPupilCensusRepository = Substitute.For<IPupilCensusRepository>();
+
+    private readonly SchoolPopulation _dummySchoolPopulation = new(
+        new Statistic<int>.WithValue(100),
+        new Statistic<int>.WithValue(10),
+        new Statistic<decimal>.WithValue(10.0m),
+        new Statistic<int>.WithValue(11),
+        new Statistic<decimal>.WithValue(11.0m),
+        new Statistic<int>.WithValue(12),
+        new Statistic<decimal>.WithValue(12.0m),
+        new Statistic<int>.WithValue(13),
+        new Statistic<decimal>.WithValue(13.0m)
+    );
+    
+    public TrustPupilServiceTests()
+    {
+        _mockPupilCensusRepository.GetMostRecentPopulationStatisticsForTrustAsync(Arg.Any<string>())
+            .Returns(new TrustStatistics<SchoolPopulation>());
+
+        var dummyStatisticsForTrust = new TrustStatistics<SchoolPopulation>
+        {
+            { 123456, _dummySchoolPopulation },
+            { 234567, _dummySchoolPopulation },
+            { 345678, _dummySchoolPopulation },
+            { 456789, _dummySchoolPopulation },
+            { 567890, _dummySchoolPopulation }
+        };
+        
+        _mockPupilCensusRepository.GetMostRecentPopulationStatisticsForTrustAsync(Uid)
+            .Returns(dummyStatisticsForTrust);
+        
+        _sut = new TrustPupilService(_mockPupilCensusRepository);
+    }
+
+    [Fact]
+    public async Task GetTotalPupilCountForTrustAsync_returns_0_when_trust_is_not_found()
+    {
+        var result = await _sut.GetTotalPupilCountForTrustAsync("999999");
+        
+        result.Should().Be(0);
+    }
+    
+    [Theory]
+    [InlineData(1, 100, 100)]
+    [InlineData(5, 500, 2500)]
+    [InlineData(30, 1000,30000)]
+    public async Task GetTotalPupilCountForTrustAsync_returns_total_pupil_count_for_trust(int numberOfSchools, int pupilsPerSchool, int expectedTotal)
+    {
+        var statistics = new TrustStatistics<SchoolPopulation>();
+
+        for (var i = 0; i < numberOfSchools; i++)
+        {
+            statistics[i] = _dummySchoolPopulation with
+            {
+                PupilsOnRole = new Statistic<int>.WithValue(pupilsPerSchool)
+            };
+        }
+        
+        _mockPupilCensusRepository.GetMostRecentPopulationStatisticsForTrustAsync(Uid)
+            .Returns(statistics);
+        
+        var result = await _sut.GetTotalPupilCountForTrustAsync(Uid);
+        
+        result.Should().Be(expectedTotal);
+    }
+    
+    [Theory]
+    [InlineData(StatisticKind.Suppressed)]
+    [InlineData(StatisticKind.NotPublished)]
+    [InlineData(StatisticKind.NotApplicable)]
+    [InlineData(StatisticKind.NotAvailable)]
+    [InlineData(StatisticKind.NotYetSubmitted)]
+    public async Task GetTotalPupilCountForTrustAsync_counts_0_for_school_when_pupil_count_does_not_have_value(StatisticKind statisticKind)
+    {
+        var statistics = new TrustStatistics<SchoolPopulation>
+        {
+            [1234] = _dummySchoolPopulation with { PupilsOnRole = Statistic<int>.FromKind(statisticKind) },
+            [2345] = _dummySchoolPopulation
+        };
+        
+        _mockPupilCensusRepository.GetMostRecentPopulationStatisticsForTrustAsync(Uid)
+            .Returns(statistics);
+        
+        var result = await _sut.GetTotalPupilCountForTrustAsync(Uid);
+        
+        result.Should().Be(100);
+    }
+    
+    [Fact]
+    public async Task GetPupilCountsForSchoolsInTrustAsync_returns_empty_result_when_trust_is_not_found()
+    {
+        var result = await _sut.GetPupilCountsForSchoolsInTrustAsync("999999");
+        
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPupilCountsForSchoolsInTrustAsync_returns_pupil_counts_for_each_school_in_trust()
+    {
+        var result = await _sut.GetPupilCountsForSchoolsInTrustAsync(Uid);
+        
+        result.Should().HaveCount(5);
+        result.Keys.Should().BeEquivalentTo([123456, 234567, 345678, 456789, 567890]);
+        result.Values.Should().AllBeEquivalentTo(new Statistic<int>.WithValue(100));
+    }
+    
+    [Theory]
+    [InlineData(StatisticKind.Suppressed)]
+    [InlineData(StatisticKind.NotPublished)]
+    [InlineData(StatisticKind.NotApplicable)]
+    [InlineData(StatisticKind.NotAvailable)]
+    [InlineData(StatisticKind.NotYetSubmitted)]
+    public async Task GetPupilCountsForSchoolsInTrustAsync_returns_statistic_without_value_when_pupil_count_for_school_does_not_have_value(StatisticKind statisticKind)
+    {
+        var statistics = new TrustStatistics<SchoolPopulation>
+        {
+            [123456] = _dummySchoolPopulation with { PupilsOnRole = Statistic<int>.FromKind(statisticKind) }
+        };
+        
+        _mockPupilCensusRepository.GetMostRecentPopulationStatisticsForTrustAsync(Uid)
+            .Returns(statistics);
+        
+        var result = await _sut.GetPupilCountsForSchoolsInTrustAsync(Uid);
+        
+        result.Should().HaveCount(1);
+        result.Keys.Should().BeEquivalentTo([123456]);
+        result.Values.Should().AllBeEquivalentTo(Statistic<int>.FromKind(statisticKind));
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceGovernanceTurnoverTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceGovernanceTurnoverTests.cs
@@ -15,6 +15,7 @@ public class TrustServiceGovernanceTurnoverTests
     private readonly ITrustRepository _mockTrustRepository = Substitute.For<ITrustRepository>();
     private readonly ITrustGovernanceRepository _mockTrustGovernanceRepository = Substitute.For<ITrustGovernanceRepository>();
     private readonly IContactRepository _mockContactRepository = Substitute.For<IContactRepository>();
+    private readonly ITrustPupilService _mockTrustPupilService = Substitute.For<ITrustPupilService>();
     private readonly IDateTimeProvider _mockDateTimeProvider = Substitute.For<IDateTimeProvider>();
     private readonly MockMemoryCache _mockMemoryCache = new();
 
@@ -24,6 +25,7 @@ public class TrustServiceGovernanceTurnoverTests
             _mockTrustRepository,
             _mockTrustGovernanceRepository,
             _mockContactRepository,
+            _mockTrustPupilService,
             _mockMemoryCache.Object,
             _mockDateTimeProvider);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -27,6 +27,7 @@ public class TrustServiceTests
     private readonly ITrustRepository _mockTrustRepository = Substitute.For<ITrustRepository>();
     private readonly ITrustGovernanceRepository _mockTrustGovernanceRepository = Substitute.For<ITrustGovernanceRepository>();
     private readonly IContactRepository _mockContactRepository = Substitute.For<IContactRepository>();
+    private readonly ITrustPupilService _mockTrustPupilService = Substitute.For<ITrustPupilService>();
     private readonly IDateTimeProvider _mockDateTimeProvider = Substitute.For<IDateTimeProvider>();
     private readonly MockMemoryCache _mockMemoryCache = new();
 
@@ -36,6 +37,7 @@ public class TrustServiceTests
             _mockTrustRepository,
             _mockTrustGovernanceRepository,
             _mockContactRepository,
+            _mockTrustPupilService,
             _mockMemoryCache.Object,
             _mockDateTimeProvider);
 
@@ -263,13 +265,14 @@ public class TrustServiceTests
         var uid = "1234";
         var academiesOverview = new AcademyOverview[]
         {
-            new("1001", "LocalAuthorityA", 500, 600),
-            new("1002", "LocalAuthorityB", 400, 500),
-            new("1003", "LocalAuthorityA", 300, 400)
+            new("1001", "LocalAuthorityA", null, 600),
+            new("1002", "LocalAuthorityB", null, 500),
+            new("1003", "LocalAuthorityA", null, 400)
         };
 
         _mockAcademyRepository.GetOverviewOfAcademiesInTrustAsync(uid).Returns(Task.FromResult(academiesOverview));
         _mockTrustRepository.GetTrustOverviewAsync(uid).Returns(Task.FromResult(BaseTrustOverview with { Uid = uid }));
+        _mockTrustPupilService.GetTotalPupilCountForTrustAsync(uid).Returns(1200);
 
         // Act
         var result = await _sut.GetTrustOverviewAsync(uid);
@@ -282,7 +285,7 @@ public class TrustServiceTests
             { "LocalAuthorityA", 2 },
             { "LocalAuthorityB", 1 }
         });
-        result.TotalPupilNumbers.Should().Be(500 + 400 + 300);
+        result.TotalPupilNumbers.Should().Be(1200);
         result.TotalCapacity.Should().Be(600 + 500 + 400);
     }
 


### PR DESCRIPTION
> [!Important]
> This PR is the mainline development branch for [User Story 233765](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/233765): Build: Update pupil numbers data source at Trust level. Other branches for this feature should be merged into this one.

This PR updates the 'Trust summary' page in the 'Overview' area for a trust and the 'Pupil numbers' page in the 'Academies in this trust' area so that pupil numbers are derived from the spring census data supplied by [Compare school and college performance in England](https://www.compare-school-performance.service.gov.uk/).

## Changes

- The `PupilCensusRepository` now has a `GetMostRecentPopulationStatisticsForTrustAsync`, which uses the `gias.GroupLinks` table to get a list of all URNs for academies within the specified trust, and returns a `SchoolPopulation` representing the most recent census data for each academy returned.
- A `TrustPupilService` class has been introduced that provides the `GetTotalPupilCountForTrustAsync` and `GetPupilCountsForSchoolsInTrustAsync` methods. These provide a single aggregate figure for the entire trust and a URN-indexed set of individual figures respectively.
- The `TrustService` and `AcademyService` classes have been updated to include a dependency on the `TrustPupilService` and now retrieve pupil numbers from it.
- The `StatisticDisplayExtensions` class now provides an `DisplayPercentage` extension method to format numeric statistics as percentages.
- The `AcademyPupilNumbersServiceModel` record has been updated so that the `NumberOfPupils` and `PercentageFull` properties are `Statistic<int>` and `Statistic<float>` instead of `int?` and `float?` respectively.
- The `AcademiesInTrustAreaModel` and `OverviewAreaModel` have been updated to include Compare school and college performance in England as a data source.

## Screenshots of UI changes

### Before

The 'Trust summary' page, with all information taken from GIAS:
<img width="2419" height="3366" alt="" src="https://github.com/user-attachments/assets/899843d9-2c26-4892-9b2e-342112bd8bc8" />

The 'Pupil numbers' page, with all information taken from GIAS:
<img width="100%" height="100%" alt="" src="https://github.com/user-attachments/assets/33ba0930-b419-494b-961a-b2206d55a96f" />

### After

The 'Trust summary' page, updated to indicate its new data source:
<img width="2419" height="3411" alt="" src="https://github.com/user-attachments/assets/0dacde10-17f2-4216-b71c-6322e6878071" />

The 'Pupil numbers' page, updated to indicate its new data source:
<img width="2419" height="6078" alt="" src="https://github.com/user-attachments/assets/2ee306bf-910f-43d7-9e2a-f60fd8fcc4ca" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
