### PR TITLE
[Accessibility BUG] - Heading order seems out of sync in various pages

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolBanner.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolBanner.cshtml
@@ -7,10 +7,10 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-three-quarters">
                 <partial name="_SchoolBreadcrumbs" model="@Model"/>
-                <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3"
+                <h1 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3"
                     data-testid="school-name-heading">
                     @Model.SchoolName
-                </h2>
+                </h1>
                 <p class="govuk-body app-banner--body govuk-!-margin-bottom-0"
                    data-testid="school-type">
                     @Model.SchoolType

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolLayout.cshtml
@@ -14,7 +14,7 @@
         <main id="main-content">
           @await RenderSectionAsync("SchoolPageMessage", false)
           <header>
-            <h1 class="govuk-heading-l" data-testid="page-name">@Model.PageMetadata.PageName</h1>
+            <h2 class="govuk-heading-l" data-testid="page-name">@Model.PageMetadata.PageName</h2>
           </header>
           <partial name="Shared/NavMenu/_SubNav" model="@Model.SubNavLinks"/>
           @RenderBody()

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
@@ -5,7 +5,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <partial name="_TrustBreadcrumbs" model="@Model"/>
-        <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3" data-testid="trust-name-heading">@Model.TrustSummary.Name</h2>
+        <h1 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3" data-testid="trust-name-heading">@Model.TrustSummary.Name</h1>
         <p class="govuk-body app-banner--body govuk-!-margin-bottom-0" data-testid="trust-type">@Model.TrustSummary.Type</p>
       </div>
     </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -14,7 +14,7 @@
         <main id="main-content">
           @await RenderSectionAsync("TrustPageMessage", false)
           <header>
-            <h1 class="govuk-heading-l" data-testid="page-name">@Model.PageMetadata.PageName</h1>
+            <h2 class="govuk-heading-l" data-testid="page-name">@Model.PageMetadata.PageName</h2>
           </header>
           <partial name="Shared/NavMenu/_SubNav" model="@TrustNavMenu.GetSubNavLinks(Model)" />
           @RenderBody()


### PR DESCRIPTION
[Accessibility BUG] - Heading order seems out of sync in various pages

Ticket: https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/220685

<!-- Do you need to add any environment variables? -->

## Changes

Only two instances of H1 and H2 tags out of order

## Screenshots of UI changes

### Before

<img width="896" height="350" alt="image" src="https://github.com/user-attachments/assets/3260ff46-3481-45d6-b278-17aef8d54a85" />

### After

<img width="929" height="455" alt="image" src="https://github.com/user-attachments/assets/8eb5a7a9-1856-4e5a-8aea-f08d17b9e890" />

<img width="709" height="371" alt="image" src="https://github.com/user-attachments/assets/73ce50d1-5fb6-4a40-b1c0-dcc6fbf72450" />


## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
